### PR TITLE
feature(cli): adds version parameter to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # watskeburt
 
-get git changed files & their statuses since _any reference_
+get git changed files & their statuses since _any revision_
 
 ## what's this do?
 
@@ -13,34 +13,69 @@ modified, renamed, deleted, ...) since the reference it got passed.
 - :warning: Interface is stable-ish, but can can change until 1.0.0 is published
 - :warning: expect some rough edges for e.g. error scenarios
 
-## sample return value
+## why?
 
-```json
-[
-  { "name": "doc/cli.md", "changeType": "modified" },
-  {
-    "name": "test/report/mermaid/mermaid.spec.mjs",
-    "changeType": "renamed",
-    "oldName": "test/configs/plugins/mermaid-reporter-plugin/module-level/index.spec.mjs",
-    "similarity": 66
-  },
-  { "name": "src/not-tracked-yet.mjs", "changeType": "untracked" }
-  // ...
-]
-```
+Useful primitives to support e.g. auto-documenting pull requests, or to save
+processing power by only doing static analysis only over stuff that is changed.
 
-## cli
+There are a few packages like these like this on npm, but it seems they've
+fallen out of maintenance. More generic packages don't get plagued by this
+but for just this simple usage they're a bit overkill.
+
+## usage
+
+### cli
 
 For now there's also a simple command line interface
 
 ```
-Usage: watskeburt [options] <reference>
+Usage: cli [options] <revision>
 
-lists files & their statuses since <reference>
+lists files & their statuses since <revision>
 
 Options:
+  -V, --version             output the version number
   -T, --output-type <type>  json,regex (default: "regex")
   --tracked-only            only take tracked files into account (default: false)
   -h, --help                display help for command
+```
+
+By default this returns a regex that contains all changed files that could be
+source files in the JavaScript ecosystem (.js, .mjs, .ts, .tsx ...) that can
+be used in e.g. the `--focus` filter of dependency-cruiser:
 
 ```
+^(src/cli.mjs|src/formatters/regex.mjs|src/version.mjs)$
+```
+
+### API
+
+```javascript
+// const { convert } = require('watskeburt'); // will work in commonjs  contexts  as well
+import { convert } from "watskeburt";
+
+// list all files that differ between 'main' and
+/** @type {import('watskeburt').IChange[]} */
+const lChangedFiles = convert("main");
+```
+
+An array of changes looks something like this:
+
+```javascript
+[
+  { name: "doc/cli.md", changeType: "modified" },
+  {
+    name: "test/thing.spec.mjs",
+    changeType: "renamed",
+    oldName: "test/oldthing.spec.mjs",
+    similarity: 66,
+  },
+  { name: "src/not-tracked-yet.mjs", changeType: "untracked" },
+];
+```
+
+## What's the deal with the name?
+
+_watskeburt_ is a fast pronunciation of the Dutch sentence "Wat is er gebeurd?"
+(What has happened?), as well as the title of a song by the Dutch hip hop group
+"De Jeugd van Tegenwoordig".

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "bin": "src/cli.mjs",
   "main": "dist/cjs-bundle.js",
   "module": "src/main.mjs",
+  "sideEffects": false,
   "exports": {
     ".": [
       {
@@ -26,7 +27,9 @@
     "README.md"
   ],
   "scripts": {
-    "build": "esbuild src/main.mjs --format=cjs --target=node12 --platform=node --bundle --global-name=wkbtcjs --minify --outfile=dist/cjs-bundle.js",
+    "build": "run-s build:version build:dist",
+    "build:version": "node tools/get-version.mjs > src/version.mjs",
+    "build:dist": "esbuild src/main.mjs --format=cjs --target=node12 --platform=node --bundle --global-name=wkbtcjs --minify --outfile=dist/cjs-bundle.js",
     "clean": "rm -rf dist",
     "test": "mocha \"src/**/*.spec.mjs\"",
     "test:cover": "c8 --check-coverage --statements 100 --branches 100 --functions 100 --lines 100 --exclude \"**/*.spec.mjs\" --reporter text-summary --reporter html --reporter json-summary npm test",
@@ -53,7 +56,8 @@
     "dependency-cruiser": "^11.11.0",
     "esbuild": "^0.14.48",
     "mocha": "^10.0.0",
-    "npm-run-all": "^4.1.5"
+    "npm-run-all": "^4.1.5",
+    "prettier": "^2.7.1"
   },
   "dependencies": {
     "commander": "^9.3.0"

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -2,12 +2,14 @@
 
 import { program } from "commander";
 import { convert } from "./main.mjs";
+import { version } from "./version.mjs";
 
 program
-  .description("lists files & their statuses since <reference>")
+  .description("lists files & their statuses since <revision>")
+  .version(version)
   .option("-T, --output-type <type>", "json,regex", "regex")
   .option("--tracked-only", "only take tracked files into account", false)
-  .arguments("<reference>")
+  .arguments("<revision>")
   .parse(process.argv);
 
 if (program.args[0]) {

--- a/src/formatters/regex.mjs
+++ b/src/formatters/regex.mjs
@@ -9,7 +9,17 @@ import { extname } from "node:path";
  */
 export default function formatToRegex(
   pChanges,
-  pExtensions = [".js", ".ts", ".mjs", ".cjs"],
+  pExtensions = [
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+    ".ts",
+    ".tsx",
+    ".vue",
+    ".vuex",
+    ".json",
+  ],
   pChangeTypes = ["modified", "added", "renamed", "copied", "untracked"]
 ) {
   const lChanges = pChanges

--- a/src/version.mjs
+++ b/src/version.mjs
@@ -1,0 +1,1 @@
+export const version = "0.2.0";

--- a/tools/get-version.mjs
+++ b/tools/get-version.mjs
@@ -1,0 +1,11 @@
+import { readFileSync } from "node:fs";
+import prettier from "prettier";
+
+const $package = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8")
+);
+process.stdout.write(
+  prettier.format(`export const version = "${$package.version}";\n`, {
+    parser: "babel",
+  })
+);


### PR DESCRIPTION
## Description

- adds a --version parameter to the cli
- expands the documentation in README a bit.
- expands what the regex formatter by default judges to be useful extensions

## Motivation and Context

- useful for debugging & support requests.

## How Has This Been Tested?

- [x] automated non-regression

## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/develop/.github/CONTRIBUTING.md).
