### PR TITLE
ci: adds prettier check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           node-version: ${{matrix.node-version}}
       - run: npm install
       - run: npm run depcruise
+      - run: npm run lint
       - run: npm run test:cover
       - name: emit coverage results to step summary
         run: |

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "run-s build:version build:dist",
+    "build": "npm-run-all --sequential build:version build:dist",
     "build:version": "node tools/get-version.mjs > src/version.mjs",
     "build:dist": "esbuild src/main.mjs --format=cjs --target=node12 --platform=node --bundle --global-name=wkbtcjs --minify --outfile=dist/cjs-bundle.js",
     "clean": "rm -rf dist",
@@ -42,8 +42,12 @@
     "depcruise:html": "depcruise src --progress --config --output-type err-html --output-to dependency-violation-report.html",
     "depcruise:text": "depcruise src --progress --config --output-type text",
     "depcruise:focus": "depcruise src --progress --config --output-type text --focus",
+    "lint": "npm-run-all --parallel --aggregate-output lint:format",
+    "lint:fix": "npm-run-all --parallel --aggregate-output lint:format:fix",
+    "lint:format": "prettier --check \"{src,tools}/**/*.mjs\" \"types/**/*.ts\" \"*.{json,yml,md,js}\"",
+    "lint:format:fix": "prettier --loglevel warn --write \"{src,tools}/**/*.mjs\" \"types/**/*.ts\" \"*.{json,yml,md,js}\"",
     "scm:stage": "git add .",
-    "version": "run-s clean build depcruise:graph scm:stage"
+    "version": "npm-run-all --sequential clean build lint depcruise:graph scm:stage"
   },
   "keywords": [
     "git",


### PR DESCRIPTION
## Description

- adds prettier check & fix scripts to package.json
- adds a lint script to package.json (with just prettier in it for now)
- adds a lint step to the ci

## Motivation and Context

- discussion-less & automatically consistent code formatting.

## How Has This Been Tested?

- [x] green ci

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (ci config, version updates, yadda)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/develop/.github/CONTRIBUTING.md).
