### PR TITLE
feature: removes the 'similarity' property that was returned for renamed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ An array of changes looks something like this:
     name: "test/thing.spec.mjs",
     changeType: "renamed",
     oldName: "test/old-thing.spec.mjs",
-    similarity: 66,
   },
   { name: "src/not-tracked-yet.mjs", changeType: "untracked" },
 ];

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "build": "npm-run-all --sequential build:version build:dist",
     "build:version": "node tools/get-version.mjs > src/version.mjs",
     "build:dist": "esbuild src/main.mjs --format=cjs --target=node12 --platform=node --bundle --global-name=wkbtcjs --minify --outfile=dist/cjs-bundle.js",
+    "check": "npm-run-all --parallel --aggregate-output lint depcruise test:cover",
     "clean": "rm -rf dist",
     "test": "mocha \"src/**/*.spec.mjs\"",
     "test:cover": "c8 --check-coverage --statements 100 --branches 100 --functions 100 --lines 100 --exclude \"**/*.spec.mjs\" --reporter text-summary --reporter html --reporter json-summary npm test",

--- a/src/convert-to-change-object.mjs
+++ b/src/convert-to-change-object.mjs
@@ -76,12 +76,6 @@ export function convertDiffLine(pString) {
     lReturnValue.changeType = changeChar2ChangeType(
       lMatchResult.groups.changeType
     );
-    if (lMatchResult.groups.similarity) {
-      lReturnValue.similarity = Number.parseInt(
-        lMatchResult.groups.similarity,
-        10
-      );
-    }
     if (lMatchResult.groups.newName) {
       lReturnValue.name = lMatchResult.groups.newName;
       lReturnValue.oldName = lMatchResult.groups.name;

--- a/src/convert-to-change-object.spec.mjs
+++ b/src/convert-to-change-object.spec.mjs
@@ -34,7 +34,6 @@ describe("convert diff line to change object", () => {
       ),
       {
         changeType: "renamed",
-        similarity: 66,
         name: "test/report/markdown/markdown-short.spec.mjs",
         oldName: "test/report/markdown/markdown.spec.mjs",
       }
@@ -85,7 +84,6 @@ describe("convert a bunch of diff lines to an array of change objects", () => {
           changeType: "renamed",
           name: "to",
           oldName: "from",
-          similarity: 100,
         },
       ]
     );

--- a/types/watskeburt.d.ts
+++ b/types/watskeburt.d.ts
@@ -22,10 +22,6 @@ export interface IChange {
    */
   changeType: changeTypeType;
   /**
-   * if the file was renamed: the % of similarity (range: 0 - 100)
-   */
-  similarity?: Number;
-  /**
    * if the file was renamed: what the old file's name was
    */
   oldName?: string;


### PR DESCRIPTION
## Description

- removes the 'similarity' property that was returned for renamed files

This would've been a breaking change if we'd been on a major version. We're not yet, though, so no major bumping.

## Motivation and Context

- it's cute, but I don't see a use for it at the moment

## How Has This Been Tested?
- [x] green ci
- [x] adapted UT's

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/main/.github/CONTRIBUTING.md).
