### PR TITLE
feature: makes 'revision' argument optional in the cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,17 @@ source files in the JavaScript ecosystem (.js, .mjs, .ts, .tsx ...) that can
 be used in e.g. the `--focus` filter of dependency-cruiser:
 
 ```
-Usage: cli [options] <revision>
+Usage: cli [options] [revision]
 
-lists files & their statuses since <revision>
+lists files & their statuses since [revision].
+
+-> When you don't pass a revision the revision defaults to the current one.
 
 Options:
--V, --version output the version number
--T, --output-type <type> json,regex (default: "regex")
---tracked-only only take tracked files into account (default: false)
--h, --help display help for command
-
+  -V, --version             output the version number
+  -T, --output-type <type>  json,regex (default: "regex")
+  --tracked-only            only take tracked files into account (default: false)
+  -h, --help                display help for command
 ```
 
 ### :scroll: API

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -6,19 +6,18 @@ import { list } from "./main.mjs";
 import { VERSION } from "./version.mjs";
 
 program
-  .description("lists files & their statuses since <revision>")
+  .description(
+    "lists files & their statuses since [revision].\n\n" +
+      "-> When you don't pass a revision the revision defaults to the current one."
+  )
   .version(VERSION)
   .option("-T, --output-type <type>", "json,regex", "regex")
   .option("--tracked-only", "only take tracked files into account", false)
-  .arguments("<revision>")
+  .arguments("[revision]")
   .parse(process.argv);
 
-if (program.args[0]) {
-  try {
-    console.log(list(program.args[0], program.opts()));
-  } catch (pError) {
-    console.error(`ERROR: ${pError.message}`);
-  }
-} else {
-  program.help();
+try {
+  console.log(list(program.args[0], program.opts()));
+} catch (pError) {
+  console.error(`ERROR: ${pError.message}`);
 }


### PR DESCRIPTION
## Description
- makes 'revision' argument optional in the cli
- when not provided defaults to the current revision

## Motivation and Context

- Defaults are _tight_

## How Has This Been Tested?

- [x] green ci
- [ ] manual check against the cli

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/main/.github/CONTRIBUTING.md).
