### PR TITLE
feature: expands default extensions regex formatter takes into account

### DIFF
--- a/src/formatters/regex.mjs
+++ b/src/formatters/regex.mjs
@@ -11,24 +11,28 @@ export default function formatToRegex(
   pChanges,
   pExtensions = [
     ".js",
-    ".jsx",
     ".mjs",
     ".cjs",
+    ".json",
+    ".jsx",
     ".ts",
     ".tsx",
     ".vue",
     ".vuex",
-    ".json",
+    ".svelte",
+    ".coffee",
+    ".litcoffee",
+    ".csx",
+    ".cjsx",
+    ".ls",
   ],
   pChangeTypes = ["modified", "added", "renamed", "copied", "untracked"]
 ) {
   const lChanges = pChanges
     .filter((pChange) => pChangeTypes.includes(pChange.changeType))
-    .map(
-      // .replace(/\./g, "\\\\.")
-      ({ name }) => name
-    )
+    .map(({ name }) => name)
     .filter((pName) => pExtensions.includes(extname(pName)))
+    // .replace(/\./g, "\\\\.")
     .join("|");
   return `^(${lChanges})$`;
 }


### PR DESCRIPTION
## Description

- see title

## Motivation and Context

- works more like expected.

Next up is supporting a cli parameter to steer the list of extensions.

## How Has This Been Tested?

- [x] green ci

## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/main/.github/CONTRIBUTING.md).
