### PR TITLE
refactor(format): use sets instead of arrays for filtering parameters in regex

### DIFF
--- a/src/formatters/regex.mjs
+++ b/src/formatters/regex.mjs
@@ -1,37 +1,46 @@
 import { extname } from "node:path";
 
+const DEFAULT_EXTENSIONS = new Set([
+  ".cjs",
+  ".cjsx",
+  ".coffee",
+  ".csx",
+  ".js",
+  ".json",
+  ".jsx",
+  ".litcoffee",
+  ".ls",
+  ".mjs",
+  ".svelte",
+  ".ts",
+  ".tsx",
+  ".vue",
+  ".vuex",
+]);
+
+const DEFAULT_CHANGE_TYPES = new Set([
+  "modified",
+  "added",
+  "renamed",
+  "copied",
+  "untracked",
+]);
 /**
  *
  * @param {import('../types/watskeburt').IChange[]} pChanges
- * @param {string[]} pExtensions
- * @param {import('../types/watskeburt').changeTypeType[]} pChangeTypes
+ * @param {Set<string>} pExtensions
+ * @param {Set<import('../types/watskeburt').changeTypeType>} pChangeTypes
  * @return {string}
  */
 export default function formatToRegex(
   pChanges,
-  pExtensions = [
-    ".cjs",
-    ".cjsx",
-    ".coffee",
-    ".csx",
-    ".js",
-    ".json",
-    ".jsx",
-    ".litcoffee",
-    ".ls",
-    ".mjs",
-    ".svelte",
-    ".ts",
-    ".tsx",
-    ".vue",
-    ".vuex",
-  ],
-  pChangeTypes = ["modified", "added", "renamed", "copied", "untracked"]
+  pExtensions = DEFAULT_EXTENSIONS,
+  pChangeTypes = DEFAULT_CHANGE_TYPES
 ) {
   const lChanges = pChanges
-    .filter((pChange) => pChangeTypes.includes(pChange.changeType))
+    .filter((pChange) => pChangeTypes.has(pChange.changeType))
     .map(({ name }) => name)
-    .filter((pName) => pExtensions.includes(extname(pName)))
+    .filter((pName) => pExtensions.has(extname(pName)))
     // .replace(/\./g, "\\\\.")
     .join("|");
   return `^(${lChanges})$`;

--- a/src/formatters/regex.spec.mjs
+++ b/src/formatters/regex.spec.mjs
@@ -15,6 +15,7 @@ describe("regex formatter", () => {
     { changeType: "unmodified", name: "unmodified.mjs" },
     { changeType: "untracked", name: "untracked.mjs" },
     { changeType: "ignored", name: "ignored.mjs" },
+    { changeType: "ignored", name: "ignored-too.js" },
   ];
 
   it("empty array yields empty regex", () => {
@@ -49,8 +50,8 @@ describe("regex formatter", () => {
     deepEqual(
       format(
         lChangesOfEachType,
-        [".mjs"],
-        ["type changed", "pairing broken", "ignored"]
+        new Set([".mjs"]),
+        new Set(["type changed", "pairing broken", "ignored"])
       ),
       "^(type-changed.mjs|pairing-broken.mjs|ignored.mjs)$"
     );
@@ -85,7 +86,7 @@ describe("regex formatter", () => {
             name: "added.zus",
           },
         ],
-        [".aap", ".noot", ".mies"]
+        new Set([".aap", ".noot", ".mies"])
       ),
       "^(added.aap|modified.aap|added.noot|added.mies)$"
     );


### PR DESCRIPTION
## Description

- makes the two optional parameters in the regex formatter Set instead of Array

## Motivation and Context

The Set data structure is better suited for the task at hand + it's typically faster than arrays of the same size according to MDN

## How Has This Been Tested?


- [x] green ci
- [x] updated unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/main/.github/CONTRIBUTING.md).
