### PR TITLE
refactor: renames list and getSHA listSync and getSHASync BREAKING

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ but for just this simple usage they're a bit overkill.
 ### :scroll: API
 
 ```javascript
-// const { list } = require('watskeburt'); // will work in commonjs  contexts  as well
-import { list, getSHA } from "watskeburt";
+// const { listSync, getSHASync } = require("watskeburt"); // in commonjs contexts you can also require it
+import { listSync, getSHASync } from "watskeburt";
 
 // print the SHA1 of the current HEAD
-console.log(getSHA());
+console.log(getSHASync());
 
 // list all files that differ between 'main' and the current revision (including
 // files not staged for commit and files not under revision control)
 /** @type {import('watskeburt').IChange[]} */
-const lChangedFiles = list("main");
+const lChangedFiles = listSync("main");
 
 // As a second parameter you can pass some options:
 /** @type {import('watskeburt').IChange[]|string} */
-const lChangedFiles = list("main", {
+const lChangedFiles = listSync("main", {
   trackedOnly: false, // when set to true leaves out files not under revision control
   outputType: "object", // other options: "json" and "regex" (as used in the CLI)
 });

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -2,7 +2,7 @@
 /* eslint-disable no-console */
 
 import { program } from "commander";
-import { list } from "./main.mjs";
+import { listSync } from "./main.mjs";
 import { VERSION } from "./version.mjs";
 
 program
@@ -17,7 +17,7 @@ program
   .parse(process.argv);
 
 try {
-  console.log(list(program.args[0], program.opts()));
+  console.log(listSync(program.args[0], program.opts()));
 } catch (pError) {
   console.error(`ERROR: ${pError.message}`);
 }

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -5,14 +5,14 @@ import {
 import { getDiffLines, getSHA1, getStatusShort } from "./git-primitives.mjs";
 import format from "./formatters/format.mjs";
 
-/** @type {import("../types/watskeburt.js").getSHA} */
-export function getSHA() {
+/** @type {import("../types/watskeburt").getSHASync} */
+export function getSHASync() {
   return getSHA1();
 }
 
-/** @type {import("../types/watskeburt.js").list} */
-export function list(pOldRevision, pOptions) {
-  const lOldRevision = pOldRevision || getSHA();
+/** @type {import("../types/watskeburt").listSync} */
+export function listSync(pOldRevision, pOptions) {
+  const lOldRevision = pOldRevision || getSHA1();
   let lChanges = convertDiffLines(getDiffLines(lOldRevision));
   const lOptions = pOptions || {};
 

--- a/types/watskeburt.d.ts
+++ b/types/watskeburt.d.ts
@@ -32,7 +32,7 @@ export type outputTypeType = "regex" | "json" | "object";
 export interface IOptions {
   /**
    * The type of output to deliver. Defaults to "object" - in which case
-   * the list function returns an IChange[] object
+   * the listSync function returns an IChange[] object
    */
   outputType: outputTypeType;
   /**
@@ -54,14 +54,14 @@ export interface IOptions {
  *                 filter what is returned and
  * @throws {Error}
  */
-export function list(
+export type listSync = (
   pOldRevision?: string,
   pOptions?: IOptions
-): IChange[] | string;
+) => IChange[] | string;
 
 /**
  * Returns the SHA1 of the current HEAD
  *
  * @throws {Error}
  */
-export function getSHA(): string;
+export type getSHASync = () => string;


### PR DESCRIPTION
## Description

- renames list and getSHA listSync and getSHASync respectively
- updates typings and other documentation
- makes the type declaration for the functions a valid one for 'ambient contexts'

The change is breaking, but there'll be no major bump as we're still in < 1.0.0 territory (see also warning in README.md).

## Motivation and Context

In the future we might want to have async versions as well. As in node itself the 'regular' name is usually the 'async' interface it would be confusing to have the regular name be the sync one.

## How Has This Been Tested?

- [x] green ci
- [x] manual tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/main/.github/CONTRIBUTING.md).
