### PR TITLE
feature: adds comparison between revisions BREAKING

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,16 @@ console.log(getSHASync());
 /** @type {import('watskeburt').IChange[]} */
 const lChangedFiles = listSync("main");
 
-// As a second parameter you can pass some options:
+// list all files that differ between 'v0.6.1' and 'v0.7.1' (by definition
+// won't include files staged for commit and/ or not under revision control)
+/** @type {import('watskeburt').IChange[]} */
+const lChangedFiles = listSync("v0.6.1", "v0.7.1");
+
+// As a third parameter you can pass some options
+// (pass null as the second parameter if you only want to compare between
+// a revision and the working tree):
 /** @type {import('watskeburt').IChange[]|string} */
-const lChangedFiles = listSync("main", {
+const lChangedFiles = listSync("main", null, {
   trackedOnly: false, // when set to true leaves out files not under revision control
   outputType: "object", // other options: "json" and "regex" (as used in the CLI)
 });

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -7,17 +7,19 @@ import { VERSION } from "./version.mjs";
 
 program
   .description(
-    "lists files & their statuses since [revision].\n\n" +
-      "-> When you don't pass a revision the revision defaults to the current one."
+    "lists files & their statuses since [old-revision] " +
+      "or between [old-revision] and [new-revision]." +
+      "\n\n" +
+      "-> When you don't pass a revision at all old-revision defaults to the current one."
   )
   .version(VERSION)
   .option("-T, --output-type <type>", "json,regex", "regex")
   .option("--tracked-only", "only take tracked files into account", false)
-  .arguments("[revision]")
+  .arguments("[old-revision] [new-revision]")
   .parse(process.argv);
 
 try {
-  console.log(listSync(program.args[0], program.opts()));
+  console.log(listSync(program.args[0], program.args[1], program.opts()));
 } catch (pError) {
   console.error(`ERROR: ${pError.message}`);
 }

--- a/src/git-primitives.mjs
+++ b/src/git-primitives.mjs
@@ -60,16 +60,27 @@ export function getStatusShort(pSpawnFunction = spawnSync) {
 /**
  *
  * @param {string} pOldRevision the target to compare against (e.g. branch name, commit, tag etc)
+ * @param {string} pNewRevision Newer revision against which to compare. Leave out or pass
+ *                 null when you want to compare against the working tree
  * @return {string}
  * @throws {Error}
  */
-export function getDiffLines(pOldRevision, pSpawnFunction = spawnSync) {
+export function getDiffLines(
+  pOldRevision,
+  pNewRevision,
+  pSpawnFunction = spawnSync
+) {
   const lErrorMap = {
-    128: `revision '${pOldRevision}' unknown `,
+    128: `revision '${pOldRevision}' ${
+      pNewRevision ? `(or '${pNewRevision}') ` : ""
+    }unknown`,
     129: `'${process.cwd()}' does not seem to be a git repository`,
   };
+
   return getGitResult(
-    ["diff", pOldRevision, "--name-status"],
+    pNewRevision
+      ? ["diff", pOldRevision, pNewRevision, "--name-status"]
+      : ["diff", pOldRevision, "--name-status"],
     lErrorMap,
     pSpawnFunction
   );

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -11,10 +11,12 @@ export function getSHASync() {
 }
 
 /** @type {import("../types/watskeburt").listSync} */
-export function listSync(pOldRevision, pOptions) {
+export function listSync(pOldRevision, pNewRevision, pOptions) {
   const lOldRevision = pOldRevision || getSHA1();
-  let lChanges = convertDiffLines(getDiffLines(lOldRevision));
+  const lNewRevision = pNewRevision || null;
   const lOptions = pOptions || {};
+
+  let lChanges = convertDiffLines(getDiffLines(lOldRevision, lNewRevision));
 
   if (!lOptions.trackedOnly) {
     lChanges = lChanges.concat(

--- a/types/watskeburt.d.ts
+++ b/types/watskeburt.d.ts
@@ -50,12 +50,15 @@ export interface IOptions {
  * @param pOldRevision The revision against which to compare. E.g. a commit-hash,
  *                 a branch or a tag. When not passed defaults to the _current_
  *                 commit hash (if there's any)
+ * @param pNewRevision Newer revision against which to compare. Leave out or pass
+ *                 null when you want to compare against the working tree
  * @param pOptions Options that influence how the changes are returned and that
  *                 filter what is returned and
  * @throws {Error}
  */
 export function listSync(
   pOldRevision?: string,
+  pNewRevision?: string,
   pOptions?: IOptions
 ): IChange[] | string;
 


### PR DESCRIPTION
## Description

- adds an extra parameter to the public listSync function so it can compare between revisions
- adds an extra parameter to the internal getDiffLines function to enable this
- updates documentation (types, readme) to reflect the addition

BREAKING because passing options to listSync now requires to pass _two_ parameters (one of which can be null b.t.w.). Still doubting whether to put the extra parameter in the _options_ in stead.

## Motivation and Context

because you sometimes need this (in an upcoming expansion of the caching feature dependency-cruiser will)

## How Has This Been Tested?

- [x] green ci
- [x] additional automated non-regression tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/main/.github/CONTRIBUTING.md).
