### PR TITLE
feature(cli): makes passing output-type more robust

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -9,7 +9,7 @@ module.exports = {
       },
       to: {
         pathNot: ["^dist/", "$1"],
-        dependencyTypesNot: ["npm"],
+        dependencyTypesNot: ["npm", "core"],
       },
     },
     {

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
-
-import { program } from "commander";
+import { EOL } from "node:os";
+import { Option, program } from "commander";
 import { listSync } from "../dist/esm-bundle.mjs";
 import { VERSION } from "./version.mjs";
 
@@ -9,13 +9,17 @@ program
   .description(
     "lists files & their statuses since [old-revision] " +
       "or between [old-revision] and [new-revision]." +
-      "\n\n" +
+      `${EOL}${EOL}` +
       "-> When you don't pass a revision at all old-revision defaults to the current one."
   )
-  .version(VERSION)
-  .option("-T, --output-type <type>", "json,regex", "regex")
+  .addOption(
+    new Option("-T, --output-type <type>", "what format to emit")
+      .choices(["json", "regex"])
+      .default("regex")
+  )
   .option("--tracked-only", "only take tracked files into account", false)
   .arguments("[old-revision] [new-revision]")
+  .version(VERSION)
   .parse(process.argv);
 
 try {


### PR DESCRIPTION
## Description, Motivation and Context

- uses commander configuration to make parsing output-type more robust so the user gets better feedback and is less likely to pass a wrong option.
- some small campingsite rule type updates


## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/main/.github/CONTRIBUTING.md).
