### PR TITLE
refactor(test): replaces mocha with node:test

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -124,6 +124,9 @@ export default {
       from: {},
       to: {
         couldNotResolve: true,
+        // https://github.com/nodejs/node/issues/42785 - node:test is not enumerated in builtinModules
+        // and won't ever be. Workaround in dependency-cruiser coming up. For now: ignore node:test
+        path: "node:test",
       },
     },
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16.x
+          - 18.x
           - 20.x
         platform:
           - ubuntu-latest
@@ -56,9 +56,9 @@ jobs:
           node-version: ${{matrix.node-version}}
       - run: npm install
       - run: npm run depcruise
-        if: matrix.node-version != '16.x'
-      - name: lint on platforms other than 16.x
-        if: matrix.node-version != '16.x'
+        if: matrix.node-version != '18.x'
+      - name: lint on platforms other than 18.x
+        if: matrix.node-version != '18.x'
         run: npm run lint
       - run: npm run test:cover
       - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 18.x
+          - 16.x
           - 20.x
         platform:
           - ubuntu-latest
@@ -56,11 +56,14 @@ jobs:
           node-version: ${{matrix.node-version}}
       - run: npm install
       - run: npm run depcruise
-        if: matrix.node-version != '18.x'
-      - name: lint on platforms other than 18.x
-        if: matrix.node-version != '18.x'
+        if: matrix.node-version != '16.x'
+      - name: lint on platforms other than 16.x
+        if: matrix.node-version != '16.x'
         run: npm run lint
       - run: npm run test:cover
+        if: matrix.node-version != '16.x'
+      - run: npm run test:only-for-node-16-without-the-test-reporter
+        if: matrix.node-version == '16.x'
       - run: npm run build
       - name: emit coverage results to step summary
         if: always() && matrix.node-version == env.NODE_LATEST

--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,6 +1,0 @@
-module.exports = {
-  extension: ["ts", "mjs"],
-  reporter: "dot",
-  spec: "src/**/*.spec.ts",
-  loader: "ts-node/esm",
-};

--- a/dist/esm/cli.js
+++ b/dist/esm/cli.js
@@ -13,7 +13,7 @@ Options:
   --trackedOnly            only take tracked files into account (default: false)
   -V, --version            output the version number
   -h, --help               display help for command${EOL}`;
-export async function cli(pArguments = process.argv.slice(2), pOutStream = process.stdout, pErrorStream = process.stderr) {
+export async function cli(pArguments = process.argv.slice(2), pOutStream = process.stdout, pErrorStream = process.stderr, pErrorExitCode = 1) {
     try {
         const lArguments = getArguments(pArguments);
         if (lArguments.values.help) {
@@ -26,7 +26,7 @@ export async function cli(pArguments = process.argv.slice(2), pOutStream = proce
         }
         if (!outputTypeIsValid(lArguments.values.outputType)) {
             pErrorStream.write(`error: option '-T, --outputType <type>' argument '${lArguments.values.outputType}' is invalid. Allowed choices are json, regex.${EOL}`);
-            process.exitCode = 1;
+            process.exitCode = pErrorExitCode;
             return;
         }
         const lResult = await list(lArguments.positionals[0], lArguments.positionals[1], lArguments.values);
@@ -34,7 +34,7 @@ export async function cli(pArguments = process.argv.slice(2), pOutStream = proce
     }
     catch (pError) {
         pErrorStream.write(`${EOL}ERROR: ${pError.message}${EOL}${EOL}`);
-        process.exitCode = 1;
+        process.exitCode = pErrorExitCode;
     }
 }
 function getArguments(pArguments) {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "clean": "rm -rf dist",
     "test": "node --no-warnings --loader 'ts-node/esm' --test-reporter dot --test src/*.spec.ts src/**/*.spec.ts",
     "test:cover": "c8 npm test",
+    "test:only-for-node-16-without-the-test-reporter": "node --no-warnings --loader 'ts-node/esm' --test src/*.spec.ts src/**/*.spec.ts",
     "depcruise": "depcruise bin dist src types",
     "depcruise:graph": "depcruise bin src types --include-only '^(bin|dist|src|types)' --output-type dot | dot -T svg | tee docs/dependency-graph.svg | depcruise-wrap-stream-in-html > docs/dependency-graph.html",
     "depcruise:graph:archi": "depcruise bin src --include-only '^(bin|dist|src|types)' --output-type archi | dot -T svg | depcruise-wrap-stream-in-html > docs/high-level-dependency-graph.html",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "depcruise:focus": "depcruise bin src types --progress --output-type text --focus",
     "depcruise:reaches": "depcruise bin src types --progress --output-type text --reaches",
     "format": "prettier --write \"{bin,src,tools}/**/*.{js,ts}\" \"types/**/*.ts\" \"*.{json,yml,md,js}\"",
-    "format:check": "prettier --loglevel warn --check \"{bin,src,tools}/**/*.ts\" \"types/**/*.ts\" \"*.{json,yml,md,js}\"",
+    "format:check": "prettier --log-level warn --check \"{bin,src,tools}/**/*.ts\" \"types/**/*.ts\" \"*.{json,yml,md,js}\"",
     "lint": "npm-run-all --parallel --aggregate-output format:check lint:eslint lint:types",
     "lint:fix": "npm-run-all --parallel --aggregate-output format lint:eslint:fix",
     "lint:eslint": "eslint bin src types tools --cache --cache-location node_modules/.cache/eslint/",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "README.md"
   ],
   "devDependencies": {
-    "@types/mocha": "10.0.1",
     "@types/node": "20.4.1",
     "@typescript-eslint/eslint-plugin": "6.0.0",
     "c8": "8.0.0",
@@ -60,7 +59,6 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-security": "1.7.1",
     "eslint-plugin-unicorn": "47.0.0",
-    "mocha": "10.2.0",
     "npm-run-all": "4.1.5",
     "prettier": "3.0.0",
     "ts-node": "10.9.1",
@@ -79,8 +77,8 @@
     "build:dist:esm": "tsc",
     "check": "npm-run-all --parallel --aggregate-output lint depcruise test:cover",
     "clean": "rm -rf dist",
-    "test": "NODE_OPTIONS=--no-warnings mocha",
-    "test:cover": "NODE_OPTIONS=--no-warnings c8 mocha",
+    "test": "node --no-warnings --loader 'ts-node/esm' --test-reporter dot --test src/*.spec.ts src/**/*.spec.ts",
+    "test:cover": "c8 npm test",
     "depcruise": "depcruise bin dist src types",
     "depcruise:graph": "depcruise bin src types --include-only '^(bin|dist|src|types)' --output-type dot | dot -T svg | tee docs/dependency-graph.svg | depcruise-wrap-stream-in-html > docs/dependency-graph.html",
     "depcruise:graph:archi": "depcruise bin src --include-only '^(bin|dist|src|types)' --output-type archi | dot -T svg | depcruise-wrap-stream-in-html > docs/high-level-dependency-graph.html",

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -29,7 +29,7 @@ describe("cli", () => {
 
   it("shows help when asked for", async () => {
     const lOutStream = new WritableTestStream(
-      /^Usage: watskeburt \[options\] \[old-revision\] \[new-revision\].*/
+      /^Usage: watskeburt \[options\] \[old-revision\] \[new-revision\].*/,
     );
     const lErrorStream = new WritableTestStream();
     await cli(["-h"], lOutStream, lErrorStream);
@@ -39,7 +39,7 @@ describe("cli", () => {
   it("shows an error when passed a non-existing argument", async () => {
     const lOutStream = new WritableTestStream();
     const lErrorStream = new WritableTestStream(
-      /.*ERROR:.*'--thisArgumentDoesNotExist'.*/
+      /.*ERROR:.*'--thisArgumentDoesNotExist'.*/,
     );
     await cli(["--thisArgumentDoesNotExist"], lOutStream, lErrorStream, 0);
   });
@@ -47,20 +47,20 @@ describe("cli", () => {
   it("shows an error when passed a non-existing revision", async () => {
     const lOutStream = new WritableTestStream();
     const lErrorStream = new WritableTestStream(
-      /.*ERROR: revision 'this-is-not-likely-to-be-a-known-revision' unknown.*/
+      /.*ERROR: revision 'this-is-not-likely-to-be-a-known-revision' unknown.*/,
     );
     await cli(
       ["this-is-not-likely-to-be-a-known-revision"],
       lOutStream,
       lErrorStream,
-      0
+      0,
     );
   });
 
   it("shows an error when passed a non-existing reporter type", async () => {
     const lOutStream = new WritableTestStream();
     const lErrorStream = new WritableTestStream(
-      /^error:.*argument 'invalid-reporter-type' is invalid.*/
+      /^error:.*argument 'invalid-reporter-type' is invalid.*/,
     );
     await cli(["-T", "invalid-reporter-type"], lOutStream, lErrorStream, 0);
   });
@@ -71,7 +71,7 @@ describe("cli", () => {
     await cli(
       ["-T", "json", "--trackedOnly", getSHASync(), getSHASync()],
       lOutStream,
-      lErrorStream
+      lErrorStream,
     );
   });
 });

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -1,7 +1,8 @@
 import { match } from "node:assert";
 import { Writable } from "node:stream";
-import { getSHASync } from "./main.js";
+import { describe, it } from "node:test";
 import { cli } from "./cli.js";
+import { getSHASync } from "./main.js";
 
 class WritableTestStream extends Writable {
   expected = /^$/;
@@ -28,7 +29,7 @@ describe("cli", () => {
 
   it("shows help when asked for", async () => {
     const lOutStream = new WritableTestStream(
-      /^Usage: watskeburt \[options\] \[old-revision\] \[new-revision\].*/,
+      /^Usage: watskeburt \[options\] \[old-revision\] \[new-revision\].*/
     );
     const lErrorStream = new WritableTestStream();
     await cli(["-h"], lOutStream, lErrorStream);
@@ -38,29 +39,30 @@ describe("cli", () => {
   it("shows an error when passed a non-existing argument", async () => {
     const lOutStream = new WritableTestStream();
     const lErrorStream = new WritableTestStream(
-      /.*ERROR:.*'--thisArgumentDoesNotExist'.*/,
+      /.*ERROR:.*'--thisArgumentDoesNotExist'.*/
     );
-    await cli(["--thisArgumentDoesNotExist"], lOutStream, lErrorStream);
+    await cli(["--thisArgumentDoesNotExist"], lOutStream, lErrorStream, 0);
   });
 
   it("shows an error when passed a non-existing revision", async () => {
     const lOutStream = new WritableTestStream();
     const lErrorStream = new WritableTestStream(
-      /.*ERROR: revision 'this-is-not-likely-to-be-a-known-revision' unknown.*/,
+      /.*ERROR: revision 'this-is-not-likely-to-be-a-known-revision' unknown.*/
     );
     await cli(
       ["this-is-not-likely-to-be-a-known-revision"],
       lOutStream,
       lErrorStream,
+      0
     );
   });
 
   it("shows an error when passed a non-existing reporter type", async () => {
     const lOutStream = new WritableTestStream();
     const lErrorStream = new WritableTestStream(
-      /^error:.*argument 'invalid-reporter-type' is invalid.*/,
+      /^error:.*argument 'invalid-reporter-type' is invalid.*/
     );
-    await cli(["-T", "invalid-reporter-type"], lOutStream, lErrorStream);
+    await cli(["-T", "invalid-reporter-type"], lOutStream, lErrorStream, 0);
   });
 
   it("emits ", async () => {
@@ -69,7 +71,7 @@ describe("cli", () => {
     await cli(
       ["-T", "json", "--trackedOnly", getSHASync(), getSHASync()],
       lOutStream,
-      lErrorStream,
+      lErrorStream
     );
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ export async function cli(
   pArguments: string[] = process.argv.slice(2),
   pOutStream: Writable = process.stdout,
   pErrorStream: Writable = process.stderr,
-  pErrorExitCode: number = 1
+  pErrorExitCode: number = 1,
 ) {
   try {
     const lArguments = getArguments(pArguments);
@@ -49,7 +49,7 @@ export async function cli(
 
     if (!outputTypeIsValid(lArguments.values.outputType)) {
       pErrorStream.write(
-        `error: option '-T, --outputType <type>' argument '${lArguments.values.outputType}' is invalid. Allowed choices are json, regex.${EOL}`
+        `error: option '-T, --outputType <type>' argument '${lArguments.values.outputType}' is invalid. Allowed choices are json, regex.${EOL}`,
       );
       process.exitCode = pErrorExitCode;
       return;
@@ -58,7 +58,7 @@ export async function cli(
     const lResult = await list(
       lArguments.positionals[0],
       lArguments.positionals[1],
-      lArguments.values
+      lArguments.values,
     );
     pOutStream.write(`${lResult}${EOL}`);
   } catch (pError: unknown) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ export async function cli(
   pArguments: string[] = process.argv.slice(2),
   pOutStream: Writable = process.stdout,
   pErrorStream: Writable = process.stderr,
+  pErrorExitCode: number = 1
 ) {
   try {
     const lArguments = getArguments(pArguments);
@@ -48,22 +49,22 @@ export async function cli(
 
     if (!outputTypeIsValid(lArguments.values.outputType)) {
       pErrorStream.write(
-        `error: option '-T, --outputType <type>' argument '${lArguments.values.outputType}' is invalid. Allowed choices are json, regex.${EOL}`,
+        `error: option '-T, --outputType <type>' argument '${lArguments.values.outputType}' is invalid. Allowed choices are json, regex.${EOL}`
       );
-      process.exitCode = 1;
+      process.exitCode = pErrorExitCode;
       return;
     }
 
     const lResult = await list(
       lArguments.positionals[0],
       lArguments.positionals[1],
-      lArguments.values,
+      lArguments.values
     );
     pOutStream.write(`${lResult}${EOL}`);
   } catch (pError: unknown) {
     pErrorStream.write(`${EOL}ERROR: ${(pError as Error).message}${EOL}${EOL}`);
     // eslint-disable-next-line require-atomic-updates
-    process.exitCode = 1;
+    process.exitCode = pErrorExitCode;
   }
 }
 

--- a/src/convert-to-change-object.spec.ts
+++ b/src/convert-to-change-object.spec.ts
@@ -14,7 +14,7 @@ describe("convert diff line to change object", () => {
       {
         changeType: "modified",
         name: "test/report/markdown/markdown.spec.mjs",
-      }
+      },
     );
   });
 
@@ -24,20 +24,20 @@ describe("convert diff line to change object", () => {
       {
         changeType: "added",
         name: "test/report/markdown/markdown.spec.mjs",
-      }
+      },
     );
   });
 
   it("recognizes Renamed files", () => {
     deepEqual(
       convertDiffLine(
-        "R066\ttest/report/markdown/markdown.spec.mjs\ttest/report/markdown/markdown-short.spec.mjs"
+        "R066\ttest/report/markdown/markdown.spec.mjs\ttest/report/markdown/markdown-short.spec.mjs",
       ),
       {
         changeType: "renamed",
         name: "test/report/markdown/markdown-short.spec.mjs",
         oldName: "test/report/markdown/markdown.spec.mjs",
-      }
+      },
     );
   });
 
@@ -86,7 +86,7 @@ describe("convert a bunch of diff lines to an array of change objects", () => {
           name: "to",
           oldName: "from",
         },
-      ]
+      ],
     );
   });
 });
@@ -138,7 +138,7 @@ describe("convert status lines to change objects", () => {
           "?? nottracked",
           "!! ignore",
           "D  deleted",
-        ].join("\n")
+        ].join("\n"),
       ),
       [
         {
@@ -166,7 +166,7 @@ describe("convert status lines to change objects", () => {
           changeType: "deleted",
           name: "deleted",
         },
-      ]
+      ],
     );
   });
 });

--- a/src/convert-to-change-object.spec.ts
+++ b/src/convert-to-change-object.spec.ts
@@ -1,4 +1,5 @@
 import { deepEqual } from "node:assert";
+import { describe, it } from "node:test";
 import {
   convertDiffLine,
   convertDiffLines,
@@ -13,7 +14,7 @@ describe("convert diff line to change object", () => {
       {
         changeType: "modified",
         name: "test/report/markdown/markdown.spec.mjs",
-      },
+      }
     );
   });
 
@@ -23,20 +24,20 @@ describe("convert diff line to change object", () => {
       {
         changeType: "added",
         name: "test/report/markdown/markdown.spec.mjs",
-      },
+      }
     );
   });
 
   it("recognizes Renamed files", () => {
     deepEqual(
       convertDiffLine(
-        "R066\ttest/report/markdown/markdown.spec.mjs\ttest/report/markdown/markdown-short.spec.mjs",
+        "R066\ttest/report/markdown/markdown.spec.mjs\ttest/report/markdown/markdown-short.spec.mjs"
       ),
       {
         changeType: "renamed",
         name: "test/report/markdown/markdown-short.spec.mjs",
         oldName: "test/report/markdown/markdown.spec.mjs",
-      },
+      }
     );
   });
 
@@ -85,7 +86,7 @@ describe("convert a bunch of diff lines to an array of change objects", () => {
           name: "to",
           oldName: "from",
         },
-      ],
+      ]
     );
   });
 });
@@ -137,7 +138,7 @@ describe("convert status lines to change objects", () => {
           "?? nottracked",
           "!! ignore",
           "D  deleted",
-        ].join("\n"),
+        ].join("\n")
       ),
       [
         {
@@ -165,7 +166,7 @@ describe("convert status lines to change objects", () => {
           changeType: "deleted",
           name: "deleted",
         },
-      ],
+      ]
     );
   });
 });

--- a/src/formatters/format.spec.ts
+++ b/src/formatters/format.spec.ts
@@ -1,4 +1,5 @@
 import { deepEqual } from "node:assert";
+import { describe, it } from "node:test";
 import format from "./format.js";
 
 describe("format", () => {

--- a/src/formatters/json.spec.ts
+++ b/src/formatters/json.spec.ts
@@ -22,7 +22,7 @@ describe("json formatter", () => {
     "changeType": "modified",
     "name": "changed.mjs"
   }
-]`
+]`,
     );
   });
 });

--- a/src/formatters/json.spec.ts
+++ b/src/formatters/json.spec.ts
@@ -1,4 +1,5 @@
 import { deepEqual } from "node:assert";
+import { describe, it } from "node:test";
 import format from "./json.js";
 
 describe("json formatter", () => {
@@ -21,7 +22,7 @@ describe("json formatter", () => {
     "changeType": "modified",
     "name": "changed.mjs"
   }
-]`,
+]`
     );
   });
 });

--- a/src/formatters/regex.spec.ts
+++ b/src/formatters/regex.spec.ts
@@ -27,14 +27,14 @@ describe("regex formatter", () => {
   it("one file in diff yields regex with that thing", () => {
     deepEqual(
       format([{ changeType: "added", name: "added.mjs" }]),
-      "^(added\\.mjs)$"
+      "^(added\\.mjs)$",
     );
   });
 
   it("one file in diff with a backslash in its name (wut) yields regex with that thing", () => {
     deepEqual(
       format([{ changeType: "added", name: "ad\\ded.mjs" }]),
-      "^(ad\\\\ded\\.mjs)$"
+      "^(ad\\\\ded\\.mjs)$",
     );
   });
 
@@ -44,14 +44,14 @@ describe("regex formatter", () => {
         { changeType: "added", name: "added.mjs" },
         { changeType: "modified", name: "changed.mjs" },
       ]),
-      "^(added\\.mjs|changed\\.mjs)$"
+      "^(added\\.mjs|changed\\.mjs)$",
     );
   });
 
   it("by default only takes changes into account that changed the contents + untracked files", () => {
     deepEqual(
       format(lChangesOfEachType),
-      "^(added\\.mjs|copied\\.mjs|modified\\.mjs|renamed\\.mjs|untracked\\.mjs)$"
+      "^(added\\.mjs|copied\\.mjs|modified\\.mjs|renamed\\.mjs|untracked\\.mjs)$",
     );
   });
 
@@ -60,9 +60,9 @@ describe("regex formatter", () => {
       format(
         lChangesOfEachType,
         new Set([".mjs"]),
-        new Set(["type changed", "pairing broken", "ignored"])
+        new Set(["type changed", "pairing broken", "ignored"]),
       ),
-      "^(type-changed\\.mjs|pairing-broken\\.mjs|ignored\\.mjs)$"
+      "^(type-changed\\.mjs|pairing-broken\\.mjs|ignored\\.mjs)$",
     );
   });
 
@@ -95,9 +95,9 @@ describe("regex formatter", () => {
             name: "added.zus",
           },
         ],
-        new Set([".aap", ".noot", ".mies"])
+        new Set([".aap", ".noot", ".mies"]),
       ),
-      "^(added\\.aap|modified\\.aap|added\\.noot|added\\.mies)$"
+      "^(added\\.aap|modified\\.aap|added\\.noot|added\\.mies)$",
     );
   });
 });

--- a/src/formatters/regex.spec.ts
+++ b/src/formatters/regex.spec.ts
@@ -1,4 +1,5 @@
 import { deepEqual } from "node:assert";
+import { describe, it } from "node:test";
 import type { IChange } from "../../types/watskeburt.js";
 import format from "./regex.js";
 
@@ -26,14 +27,14 @@ describe("regex formatter", () => {
   it("one file in diff yields regex with that thing", () => {
     deepEqual(
       format([{ changeType: "added", name: "added.mjs" }]),
-      "^(added\\.mjs)$",
+      "^(added\\.mjs)$"
     );
   });
 
   it("one file in diff with a backslash in its name (wut) yields regex with that thing", () => {
     deepEqual(
       format([{ changeType: "added", name: "ad\\ded.mjs" }]),
-      "^(ad\\\\ded\\.mjs)$",
+      "^(ad\\\\ded\\.mjs)$"
     );
   });
 
@@ -43,14 +44,14 @@ describe("regex formatter", () => {
         { changeType: "added", name: "added.mjs" },
         { changeType: "modified", name: "changed.mjs" },
       ]),
-      "^(added\\.mjs|changed\\.mjs)$",
+      "^(added\\.mjs|changed\\.mjs)$"
     );
   });
 
   it("by default only takes changes into account that changed the contents + untracked files", () => {
     deepEqual(
       format(lChangesOfEachType),
-      "^(added\\.mjs|copied\\.mjs|modified\\.mjs|renamed\\.mjs|untracked\\.mjs)$",
+      "^(added\\.mjs|copied\\.mjs|modified\\.mjs|renamed\\.mjs|untracked\\.mjs)$"
     );
   });
 
@@ -59,9 +60,9 @@ describe("regex formatter", () => {
       format(
         lChangesOfEachType,
         new Set([".mjs"]),
-        new Set(["type changed", "pairing broken", "ignored"]),
+        new Set(["type changed", "pairing broken", "ignored"])
       ),
-      "^(type-changed\\.mjs|pairing-broken\\.mjs|ignored\\.mjs)$",
+      "^(type-changed\\.mjs|pairing-broken\\.mjs|ignored\\.mjs)$"
     );
   });
 
@@ -94,9 +95,9 @@ describe("regex formatter", () => {
             name: "added.zus",
           },
         ],
-        new Set([".aap", ".noot", ".mies"]),
+        new Set([".aap", ".noot", ".mies"])
       ),
-      "^(added\\.aap|modified\\.aap|added\\.noot|added\\.mies)$",
+      "^(added\\.aap|modified\\.aap|added\\.noot|added\\.mies)$"
     );
   });
 });

--- a/src/git-primitives-sync.spec.ts
+++ b/src/git-primitives-sync.spec.ts
@@ -14,7 +14,7 @@ describe("git-primitives-sync - diff --name-status ", () => {
       () => {
         getDiffLinesSync("this-is-not-a-real-revision");
       },
-      { message: /revision 'this-is-not-a-real-revision' unknown/ }
+      { message: /revision 'this-is-not-a-real-revision' unknown/ },
     );
   });
 
@@ -23,7 +23,7 @@ describe("git-primitives-sync - diff --name-status ", () => {
       () => {
         getDiffLinesSync("not-a-revision", "neither-is-this");
       },
-      { message: "revision 'not-a-revision' (or 'neither-is-this') unknown" }
+      { message: "revision 'not-a-revision' (or 'neither-is-this') unknown" },
     );
   });
 
@@ -43,7 +43,7 @@ describe("git-primitives-sync - diff --name-status ", () => {
       const lResult = getDiffLinesSync(
         "this-is-a-real-branch",
         undefined,
-        fakeSpawnSync
+        fakeSpawnSync,
       );
       deepEqual(lExpected, lResult);
     });
@@ -60,7 +60,7 @@ describe("git-primitives-sync - diff --name-status ", () => {
     const lResult = getDiffLinesSync(
       "this-is-a-real-branch",
       undefined,
-      fakeSpawnSync
+      fakeSpawnSync,
     );
     deepEqual(lExpected, lResult);
   });
@@ -82,7 +82,7 @@ describe("git-primitives-sync - diff --name-status ", () => {
     const lResult = getDiffLinesSync(
       "this-is-a-real-branch",
       "this-is-a-newer-branch",
-      fakeSpawnSync
+      fakeSpawnSync,
     );
     deepEqual(lExpected, lResult);
   });
@@ -95,7 +95,7 @@ describe("git-primitives-sync - diff --name-status ", () => {
       () => {
         getDiffLinesSync("main", undefined, fakeSpawnSync);
       },
-      { message: /does not seem to be a git repository/ }
+      { message: /does not seem to be a git repository/ },
     );
   });
 });
@@ -109,7 +109,7 @@ describe("git-primitives-sync - status", () => {
       () => {
         getStatusShortSync(fakeSpawnSync);
       },
-      { message: "git executable not found" }
+      { message: "git executable not found" },
     );
   });
 
@@ -121,7 +121,7 @@ describe("git-primitives-sync - status", () => {
       () => {
         getStatusShortSync(fakeSpawnSync);
       },
-      { message: /internal spawn error: / }
+      { message: /internal spawn error: / },
     );
   });
 
@@ -133,7 +133,7 @@ describe("git-primitives-sync - status", () => {
       () => {
         getStatusShortSync(fakeSpawnSync);
       },
-      { message: "internal git error: 667 (neighbor of the beast)" }
+      { message: "internal git error: 667 (neighbor of the beast)" },
     );
   });
 
@@ -145,7 +145,7 @@ describe("git-primitives-sync - status", () => {
       () => {
         getStatusShortSync(fakeSpawnSync);
       },
-      { message: "internal git error: undefined (neighbor of the beast)" }
+      { message: "internal git error: undefined (neighbor of the beast)" },
     );
   });
 
@@ -157,7 +157,7 @@ describe("git-primitives-sync - status", () => {
       () => {
         getStatusShortSync(fakeSpawnSync);
       },
-      { message: /does not seem to be a git repository/ }
+      { message: /does not seem to be a git repository/ },
     );
   });
 

--- a/src/git-primitives-sync.spec.ts
+++ b/src/git-primitives-sync.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-undefined */
 /* eslint-disable unicorn/consistent-function-scoping */
 import { deepEqual, doesNotThrow, throws, match } from "node:assert";
+import { describe, it } from "node:test";
 import {
   getDiffLinesSync,
   getSHASync,
@@ -13,7 +14,7 @@ describe("git-primitives-sync - diff --name-status ", () => {
       () => {
         getDiffLinesSync("this-is-not-a-real-revision");
       },
-      { message: /revision 'this-is-not-a-real-revision' unknown/ },
+      { message: /revision 'this-is-not-a-real-revision' unknown/ }
     );
   });
 
@@ -22,7 +23,7 @@ describe("git-primitives-sync - diff --name-status ", () => {
       () => {
         getDiffLinesSync("not-a-revision", "neither-is-this");
       },
-      { message: "revision 'not-a-revision' (or 'neither-is-this') unknown" },
+      { message: "revision 'not-a-revision' (or 'neither-is-this') unknown" }
     );
   });
 
@@ -42,7 +43,7 @@ describe("git-primitives-sync - diff --name-status ", () => {
       const lResult = getDiffLinesSync(
         "this-is-a-real-branch",
         undefined,
-        fakeSpawnSync,
+        fakeSpawnSync
       );
       deepEqual(lExpected, lResult);
     });
@@ -59,7 +60,7 @@ describe("git-primitives-sync - diff --name-status ", () => {
     const lResult = getDiffLinesSync(
       "this-is-a-real-branch",
       undefined,
-      fakeSpawnSync,
+      fakeSpawnSync
     );
     deepEqual(lExpected, lResult);
   });
@@ -81,7 +82,7 @@ describe("git-primitives-sync - diff --name-status ", () => {
     const lResult = getDiffLinesSync(
       "this-is-a-real-branch",
       "this-is-a-newer-branch",
-      fakeSpawnSync,
+      fakeSpawnSync
     );
     deepEqual(lExpected, lResult);
   });
@@ -94,7 +95,7 @@ describe("git-primitives-sync - diff --name-status ", () => {
       () => {
         getDiffLinesSync("main", undefined, fakeSpawnSync);
       },
-      { message: /does not seem to be a git repository/ },
+      { message: /does not seem to be a git repository/ }
     );
   });
 });
@@ -108,7 +109,7 @@ describe("git-primitives-sync - status", () => {
       () => {
         getStatusShortSync(fakeSpawnSync);
       },
-      { message: "git executable not found" },
+      { message: "git executable not found" }
     );
   });
 
@@ -120,7 +121,7 @@ describe("git-primitives-sync - status", () => {
       () => {
         getStatusShortSync(fakeSpawnSync);
       },
-      { message: /internal spawn error: / },
+      { message: /internal spawn error: / }
     );
   });
 
@@ -132,7 +133,7 @@ describe("git-primitives-sync - status", () => {
       () => {
         getStatusShortSync(fakeSpawnSync);
       },
-      { message: "internal git error: 667 (neighbor of the beast)" },
+      { message: "internal git error: 667 (neighbor of the beast)" }
     );
   });
 
@@ -144,7 +145,7 @@ describe("git-primitives-sync - status", () => {
       () => {
         getStatusShortSync(fakeSpawnSync);
       },
-      { message: "internal git error: undefined (neighbor of the beast)" },
+      { message: "internal git error: undefined (neighbor of the beast)" }
     );
   });
 
@@ -156,7 +157,7 @@ describe("git-primitives-sync - status", () => {
       () => {
         getStatusShortSync(fakeSpawnSync);
       },
-      { message: /does not seem to be a git repository/ },
+      { message: /does not seem to be a git repository/ }
     );
   });
 

--- a/src/git-primitives.spec.ts
+++ b/src/git-primitives.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-undefined */
 import { deepEqual, match, doesNotReject } from "node:assert";
 import { EventEmitter } from "node:events";
+import { describe, it } from "node:test";
 import { getDiffLines, getSHA, getStatusShort } from "./git-primitives.js";
 
 class FakeChildProcess extends EventEmitter {
@@ -23,12 +24,12 @@ describe("git-primitives - diff --name-status ", () => {
     } catch (pError) {
       match(
         pError.message,
-        /revision 'not-a-revision' \(or 'neither-is-this'\) unknown/,
+        /revision 'not-a-revision' \(or 'neither-is-this'\) unknown/
       );
     }
   });
 
-  it("does not error in case of a valid ref", (pDone) => {
+  it("does not error in case of a valid ref", (_, pDone) => {
     const lExpected = [
       "M       package.json",
       "M       src/get-diff-lines.mjs",
@@ -40,7 +41,7 @@ describe("git-primitives - diff --name-status ", () => {
       "this-is-a-real-branch",
       undefined,
       // @ts-expect-error is only compatible with the spawn call where it matters ...
-      () => lChildProcess,
+      () => lChildProcess
     );
     lChildProcess.stdout.emit("data", lExpected);
     lChildProcess.emit("close", 0);
@@ -55,13 +56,13 @@ describe("git-primitives - diff --name-status ", () => {
       });
   });
 
-  it("throws with 'not a git repo' when git detects that", (pDone) => {
+  it("throws with 'not a git repo' when git detects that", (_, pDone) => {
     const lChildProcess = new FakeChildProcess();
     const lPromise = getDiffLines(
       "main",
       undefined,
       // @ts-expect-error is only compatible with the spawn call where it matters ...
-      () => lChildProcess,
+      () => lChildProcess
     );
     lChildProcess.stderr.emit("data", "scary message");
     lChildProcess.emit("close", 129);
@@ -83,13 +84,13 @@ describe("git-primitives - diff --name-status ", () => {
 });
 
 describe("git-primitives - status", () => {
-  it("throws when the 'git' command couldn't be found", (pDone) => {
+  it("throws when the 'git' command couldn't be found", (_, pDone) => {
     const lChildProcess = new FakeChildProcess();
     const lPromise = getDiffLines(
       "main",
       undefined,
       // @ts-expect-error is only compatible with the spawn call where it matters ...
-      () => lChildProcess,
+      () => lChildProcess
     );
     lChildProcess.emit("error", { code: "ENOENT" });
 
@@ -107,13 +108,13 @@ describe("git-primitives - status", () => {
         }
       });
   });
-  it("throws when something unforeseen happens with spawnSync itself", (pDone) => {
+  it("throws when something unforeseen happens with spawnSync itself", (_, pDone) => {
     const lChildProcess = new FakeChildProcess();
     const lPromise = getDiffLines(
       "main",
       undefined,
       // @ts-expect-error is only compatible with the spawn call where it matters ...
-      () => lChildProcess,
+      () => lChildProcess
     );
     lChildProcess.emit("error", { code: "HELICOPTER" });
 
@@ -132,13 +133,13 @@ describe("git-primitives - status", () => {
       });
   });
 
-  it("throws when the git result contained a non-zero exit code", (pDone) => {
+  it("throws when the git result contained a non-zero exit code", (_, pDone) => {
     const lChildProcess = new FakeChildProcess();
     const lPromise = getDiffLines(
       "main",
       undefined,
       // @ts-expect-error is only compatible with the spawn call where it matters ...
-      () => lChildProcess,
+      () => lChildProcess
     );
     lChildProcess.stderr.emit("data", Buffer.from("neighbor of the beast"));
     lChildProcess.emit("close", 667);
@@ -152,7 +153,7 @@ describe("git-primitives - status", () => {
         try {
           match(
             pError.message,
-            /internal git error: 667 \(neighbor of the beast\)/,
+            /internal git error: 667 \(neighbor of the beast\)/
           );
           pDone();
         } catch (_pError) {
@@ -161,13 +162,13 @@ describe("git-primitives - status", () => {
       });
   });
 
-  it("throws when the git result contained no exit code at all", (pDone) => {
+  it("throws when the git result contained no exit code at all", (_, pDone) => {
     const lChildProcess = new FakeChildProcess();
     const lPromise = getDiffLines(
       "main",
       undefined,
       // @ts-expect-error is only compatible with the spawn call where it matters ...
-      () => lChildProcess,
+      () => lChildProcess
     );
     lChildProcess.stderr.emit("data", Buffer.from("neighbor of the beast"));
     lChildProcess.emit("close");
@@ -181,7 +182,7 @@ describe("git-primitives - status", () => {
         try {
           match(
             pError.message,
-            /internal git error: undefined \(neighbor of the beast\)/,
+            /internal git error: undefined \(neighbor of the beast\)/
           );
           pDone();
         } catch (_pError) {

--- a/src/git-primitives.spec.ts
+++ b/src/git-primitives.spec.ts
@@ -24,7 +24,7 @@ describe("git-primitives - diff --name-status ", () => {
     } catch (pError) {
       match(
         pError.message,
-        /revision 'not-a-revision' \(or 'neither-is-this'\) unknown/
+        /revision 'not-a-revision' \(or 'neither-is-this'\) unknown/,
       );
     }
   });
@@ -41,7 +41,7 @@ describe("git-primitives - diff --name-status ", () => {
       "this-is-a-real-branch",
       undefined,
       // @ts-expect-error is only compatible with the spawn call where it matters ...
-      () => lChildProcess
+      () => lChildProcess,
     );
     lChildProcess.stdout.emit("data", lExpected);
     lChildProcess.emit("close", 0);
@@ -62,7 +62,7 @@ describe("git-primitives - diff --name-status ", () => {
       "main",
       undefined,
       // @ts-expect-error is only compatible with the spawn call where it matters ...
-      () => lChildProcess
+      () => lChildProcess,
     );
     lChildProcess.stderr.emit("data", "scary message");
     lChildProcess.emit("close", 129);
@@ -90,7 +90,7 @@ describe("git-primitives - status", () => {
       "main",
       undefined,
       // @ts-expect-error is only compatible with the spawn call where it matters ...
-      () => lChildProcess
+      () => lChildProcess,
     );
     lChildProcess.emit("error", { code: "ENOENT" });
 
@@ -114,7 +114,7 @@ describe("git-primitives - status", () => {
       "main",
       undefined,
       // @ts-expect-error is only compatible with the spawn call where it matters ...
-      () => lChildProcess
+      () => lChildProcess,
     );
     lChildProcess.emit("error", { code: "HELICOPTER" });
 
@@ -139,7 +139,7 @@ describe("git-primitives - status", () => {
       "main",
       undefined,
       // @ts-expect-error is only compatible with the spawn call where it matters ...
-      () => lChildProcess
+      () => lChildProcess,
     );
     lChildProcess.stderr.emit("data", Buffer.from("neighbor of the beast"));
     lChildProcess.emit("close", 667);
@@ -153,7 +153,7 @@ describe("git-primitives - status", () => {
         try {
           match(
             pError.message,
-            /internal git error: 667 \(neighbor of the beast\)/
+            /internal git error: 667 \(neighbor of the beast\)/,
           );
           pDone();
         } catch (_pError) {
@@ -168,7 +168,7 @@ describe("git-primitives - status", () => {
       "main",
       undefined,
       // @ts-expect-error is only compatible with the spawn call where it matters ...
-      () => lChildProcess
+      () => lChildProcess,
     );
     lChildProcess.stderr.emit("data", Buffer.from("neighbor of the beast"));
     lChildProcess.emit("close");
@@ -182,7 +182,7 @@ describe("git-primitives - status", () => {
         try {
           match(
             pError.message,
-            /internal git error: undefined \(neighbor of the beast\)/
+            /internal git error: undefined \(neighbor of the beast\)/,
           );
           pDone();
         } catch (_pError) {

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -12,7 +12,7 @@ describe("main - list & listSync ", () => {
     writeFileSync(
       UNTRACKED_FILE_NAME,
       "temporary file for testing purposes, untracked",
-      { encoding: "utf8" }
+      { encoding: "utf8" },
     );
   });
 
@@ -22,7 +22,7 @@ describe("main - list & listSync ", () => {
       unlinkSync(UNTRACKED_FILE_NAME);
     } catch (pError) {
       process.stderr.write(
-        "cleaning up untracked file failed in test 'main - list & listSync'\n"
+        "cleaning up untracked file failed in test 'main - list & listSync'\n",
       );
     }
   });
@@ -50,7 +50,7 @@ describe("main - list & listSync ", () => {
           name: UNTRACKED_FILE_NAME,
           changeType: "untracked",
         },
-      ]
+      ],
     );
   });
 
@@ -63,7 +63,7 @@ describe("main - list & listSync ", () => {
           name: UNTRACKED_FILE_NAME,
           changeType: "untracked",
         },
-      ]
+      ],
     );
   });
 
@@ -76,7 +76,7 @@ describe("main - list & listSync ", () => {
           name: UNTRACKED_FILE_NAME,
           changeType: "untracked",
         },
-      ]
+      ],
     );
   });
 
@@ -89,7 +89,7 @@ describe("main - list & listSync ", () => {
           name: UNTRACKED_FILE_NAME,
           changeType: "untracked",
         },
-      ]
+      ],
     );
   });
 });

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -1,25 +1,28 @@
-import { match, deepEqual } from "node:assert";
+import { deepEqual, match } from "node:assert";
 import { unlinkSync, writeFileSync } from "node:fs";
+import { after, before, describe, it } from "node:test";
 import { IChange } from "../types/watskeburt.js";
 import { getSHA, getSHASync, list, listSync } from "./main.js";
 
 const UNTRACKED_FILE_NAME = "src/__fixtures__/untracked.txt";
 
 describe("main - list & listSync ", () => {
-  before("create an untracked file", () => {
+  // "create an untracked file"
+  before(() => {
     writeFileSync(
       UNTRACKED_FILE_NAME,
       "temporary file for testing purposes, untracked",
-      { encoding: "utf8" },
+      { encoding: "utf8" }
     );
   });
 
-  after("remove the untracked file", () => {
+  // "remove the untracked file";
+  after(() => {
     try {
       unlinkSync(UNTRACKED_FILE_NAME);
     } catch (pError) {
       process.stderr.write(
-        "cleaning up untracked file failed in test 'main - list & listSync'\n",
+        "cleaning up untracked file failed in test 'main - list & listSync'\n"
       );
     }
   });
@@ -47,7 +50,7 @@ describe("main - list & listSync ", () => {
           name: UNTRACKED_FILE_NAME,
           changeType: "untracked",
         },
-      ],
+      ]
     );
   });
 
@@ -60,7 +63,7 @@ describe("main - list & listSync ", () => {
           name: UNTRACKED_FILE_NAME,
           changeType: "untracked",
         },
-      ],
+      ]
     );
   });
 
@@ -73,7 +76,7 @@ describe("main - list & listSync ", () => {
           name: UNTRACKED_FILE_NAME,
           changeType: "untracked",
         },
-      ],
+      ]
     );
   });
 
@@ -86,7 +89,7 @@ describe("main - list & listSync ", () => {
           name: UNTRACKED_FILE_NAME,
           changeType: "untracked",
         },
-      ],
+      ]
     );
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,8 +49,7 @@
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     "types": [
-      "node",
-      "mocha"
+      "node"
     ] /* Type declaration files to be included in compilation. */,
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     // "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,


### PR DESCRIPTION
## Description

- uses `node:test` as a test runner instead of mocha

## Motivation and Context

One dependency less 

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/main/.github/CONTRIBUTING.md).
