### PR TITLE
refactor(regex formatter): uses square brackets instead of escapes to match dots

### DIFF
--- a/dist/formatters/regex.js
+++ b/dist/formatters/regex.js
@@ -34,7 +34,7 @@ export default function formatToRegex(
     .filter((pChange) => pChangeTypes.has(pChange.changeType))
     .map(({ name }) => name)
     .filter((pName) => pExtensions.has(extname(pName)))
-    .map((pName) => pName.replace(/\\/g, "\\\\").replace(/\./g, "\\."))
+    .map((pName) => pName.replace(/\\/g, "\\\\").replace(/\./g, "[.]"))
     .join("|");
   return `^(${lChanges})$`;
 }

--- a/src/formatters/regex.spec.ts
+++ b/src/formatters/regex.spec.ts
@@ -27,14 +27,14 @@ describe("regex formatter", () => {
   it("one file in diff yields regex with that thing", () => {
     deepEqual(
       format([{ changeType: "added", name: "added.mjs" }]),
-      "^(added\\.mjs)$",
+      "^(added[.]mjs)$",
     );
   });
 
   it("one file in diff with a backslash in its name (wut) yields regex with that thing", () => {
     deepEqual(
       format([{ changeType: "added", name: "ad\\ded.mjs" }]),
-      "^(ad\\\\ded\\.mjs)$",
+      "^(ad\\\\ded[.]mjs)$",
     );
   });
 
@@ -44,14 +44,14 @@ describe("regex formatter", () => {
         { changeType: "added", name: "added.mjs" },
         { changeType: "modified", name: "changed.mjs" },
       ]),
-      "^(added\\.mjs|changed\\.mjs)$",
+      "^(added[.]mjs|changed[.]mjs)$",
     );
   });
 
   it("by default only takes changes into account that changed the contents + untracked files", () => {
     deepEqual(
       format(lChangesOfEachType),
-      "^(added\\.mjs|copied\\.mjs|modified\\.mjs|renamed\\.mjs|untracked\\.mjs)$",
+      "^(added[.]mjs|copied[.]mjs|modified[.]mjs|renamed[.]mjs|untracked[.]mjs)$",
     );
   });
 
@@ -62,7 +62,7 @@ describe("regex formatter", () => {
         new Set([".mjs"]),
         new Set(["type changed", "pairing broken", "ignored"]),
       ),
-      "^(type-changed\\.mjs|pairing-broken\\.mjs|ignored\\.mjs)$",
+      "^(type-changed[.]mjs|pairing-broken[.]mjs|ignored[.]mjs)$",
     );
   });
 
@@ -97,7 +97,7 @@ describe("regex formatter", () => {
         ],
         new Set([".aap", ".noot", ".mies"]),
       ),
-      "^(added\\.aap|modified\\.aap|added\\.noot|added\\.mies)$",
+      "^(added[.]aap|modified[.]aap|added[.]noot|added[.]mies)$",
     );
   });
 });

--- a/src/formatters/regex.ts
+++ b/src/formatters/regex.ts
@@ -38,7 +38,7 @@ export default function formatToRegex(
     .filter((pChange) => pChangeTypes.has(pChange.changeType))
     .map(({ name }) => name)
     .filter((pName) => pExtensions.has(extname(pName)))
-    .map((pName) => pName.replace(/\\/g, "\\\\").replace(/\./g, "\\."))
+    .map((pName) => pName.replace(/\\/g, "\\\\").replace(/\./g, "[.]"))
     .join("|");
   return `^(${lChanges})$`;
 }


### PR DESCRIPTION
## Description

- uses square brackets instead of escapes to match dots in the regex formatter

## Motivation and Context

Arguably makes the generated regular expressions a bit more readable. 

## How Has This Been Tested?

- [x] green ci
- [x] adapted automated non-regression tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/main/.github/CONTRIBUTING.md).
