### PR TITLE
feat(cli): enables passing extensions to the (regex) reporter(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ This emits a regex that contains all changed files that could be
 source files in the JavaScript ecosystem (.js, .mjs, .ts, .tsx ...). It can
 be used in e.g. dependency-cruiser's `--focus` and `--reaches` filters.
 
-The JSON output (= the array above, serialized) also contains other extensions.
+The JSON output (= the array above, serialized) also contains all other
+extensions.
 
 ```
 Usage: watskeburt [options] [old-revision] [new-revision]

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -60,6 +60,12 @@ function getArguments(pArguments) {
 				type: "boolean",
 				default: false,
 			},
+			extensions: {
+				type: "string",
+				short: "x",
+				default:
+					"cjs,cjsx,coffee,csx,cts,js,json,jsx,litcoffee,ls,mjs,mts,svelte,ts,tsx,vue,vuex",
+			},
 			help: { type: "boolean", short: "h", default: false },
 			version: { type: "boolean", short: "V", default: false },
 		},

--- a/dist/format/format.js
+++ b/dist/format/format.js
@@ -4,6 +4,12 @@ const OUTPUT_TYPE_TO_FUNCTION = new Map([
 	["regex", formatAsRegex],
 	["json", formatAsJSON],
 ]);
-export function format(pChanges, pOutputType) {
-	return OUTPUT_TYPE_TO_FUNCTION.get(pOutputType)(pChanges);
+export function format(pChanges, pOutputType, pExtensions) {
+	const lExtensions = new Set(
+		pExtensions
+			.split(",")
+			.map((pExtension) => pExtension.trim())
+			.map((pExtension) => `.${pExtension}`),
+	);
+	return OUTPUT_TYPE_TO_FUNCTION.get(pOutputType)(pChanges, lExtensions);
 }

--- a/dist/format/regex.js
+++ b/dist/format/regex.js
@@ -1,23 +1,5 @@
 import { extname } from "node:path";
-const DEFAULT_EXTENSIONS = new Set([
-	".cjs",
-	".cjsx",
-	".coffee",
-	".csx",
-	".cts",
-	".js",
-	".json",
-	".jsx",
-	".litcoffee",
-	".ls",
-	".mjs",
-	".mts",
-	".svelte",
-	".ts",
-	".tsx",
-	".vue",
-	".vuex",
-]);
+const DEFAULT_EXTENSIONS = new Set([]);
 const DEFAULT_CHANGE_TYPES = new Set([
 	"modified",
 	"added",

--- a/dist/format/regex.js
+++ b/dist/format/regex.js
@@ -1,5 +1,4 @@
 import { extname } from "node:path";
-const DEFAULT_EXTENSIONS = new Set([]);
 const DEFAULT_CHANGE_TYPES = new Set([
 	"modified",
 	"added",
@@ -9,7 +8,7 @@ const DEFAULT_CHANGE_TYPES = new Set([
 ]);
 export default function formatAsRegex(
 	pChanges,
-	pExtensions = DEFAULT_EXTENSIONS,
+	pExtensions,
 	pChangeTypes = DEFAULT_CHANGE_TYPES,
 ) {
 	const lChanges = pChanges

--- a/dist/main.js
+++ b/dist/main.js
@@ -20,7 +20,7 @@ export async function list(pOptions) {
 		return lChanges;
 	}
 	const { format } = await import("./format/format.js");
-	return format(lChanges, lOptions.outputType);
+	return format(lChanges, lOptions.outputType, lOptions.extensions);
 }
 export function getSHA() {
 	return primitives.getSHA();

--- a/dist/map-change-type.js
+++ b/dist/map-change-type.js
@@ -1,4 +1,4 @@
-const CHANGE_CHAR_2_CHANGE_TYPE = new Map([
+const CHANGE_TYPE_MAP = new Map([
 	["A", "added"],
 	["C", "copied"],
 	["D", "deleted"],
@@ -11,6 +11,6 @@ const CHANGE_CHAR_2_CHANGE_TYPE = new Map([
 	["?", "untracked"],
 	["!", "ignored"],
 ]);
-export function changeChar2ChangeType(pChar) {
-	return CHANGE_CHAR_2_CHANGE_TYPE.get(pChar) ?? "unknown";
+export function mapChangeType(pChar) {
+	return CHANGE_TYPE_MAP.get(pChar) ?? "unknown";
 }

--- a/dist/parse-diff-lines.js
+++ b/dist/parse-diff-lines.js
@@ -1,5 +1,5 @@
 import { EOL } from "node:os";
-import { changeChar2ChangeType } from "./map-change-type.js";
+import { mapChangeType } from "./map-change-type.js";
 const DIFF_NAME_STATUS_LINE_PATTERN =
 	/^(?<type>[ACDMRTUXB])(?<similarity>[0-9]{3})?[ \t]+(?<name>[^ \t]+)[ \t]*(?<newName>[^ \t]+)?$/;
 export function parseDiffLines(pString) {
@@ -13,7 +13,7 @@ export function parseDiffLine(pString) {
 	const lMatchResult = pString.match(DIFF_NAME_STATUS_LINE_PATTERN);
 	const lReturnValue = {};
 	if (lMatchResult?.groups) {
-		lReturnValue.type = changeChar2ChangeType(lMatchResult.groups.type);
+		lReturnValue.type = mapChangeType(lMatchResult.groups.type);
 		if (lMatchResult.groups.newName) {
 			lReturnValue.name = lMatchResult.groups.newName;
 			lReturnValue.oldName = lMatchResult.groups.name;

--- a/dist/parse-status-lines.js
+++ b/dist/parse-status-lines.js
@@ -1,5 +1,5 @@
 import { EOL } from "node:os";
-import { changeChar2ChangeType } from "./map-change-type.js";
+import { mapChangeType } from "./map-change-type.js";
 const DIFF_SHORT_STATUS_LINE_PATTERN =
 	/^(?<stagedType>[ ACDMRTUXB?!])(?<unStagedType>[ ACDMRTUXB?!])[ \t]+(?<name>[^ \t]+)(( -> )(?<newName>[^ \t]+))?$/;
 export function parseStatusLines(pString) {
@@ -13,10 +13,8 @@ export function parseStatusLine(pString) {
 	const lMatchResult = pString.match(DIFF_SHORT_STATUS_LINE_PATTERN);
 	const lReturnValue = {};
 	if (lMatchResult?.groups) {
-		const lStagedType = changeChar2ChangeType(lMatchResult.groups.stagedType);
-		const lUnStagedType = changeChar2ChangeType(
-			lMatchResult.groups.unStagedType,
-		);
+		const lStagedType = mapChangeType(lMatchResult.groups.stagedType);
+		const lUnStagedType = mapChangeType(lMatchResult.groups.unStagedType);
 		lReturnValue.type =
 			lStagedType === "unmodified" ? lUnStagedType : lStagedType;
 		if (lMatchResult.groups.newName) {

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -65,6 +65,14 @@ describe("cli", () => {
     await cli(["-T", "invalid-reporter-type"], lOutStream, lErrorStream, 0);
   });
 
+  it("shows an error when --extensions didn't get a string passed", async () => {
+    const lOutStream = new WritableTestStream();
+    const lErrorStream = new WritableTestStream(
+      /ERROR: Option '-x, --extensions <value>' argument missing.*/,
+    );
+    await cli(["-x"], lOutStream, lErrorStream, 0);
+  });
+
   it("emits ", async () => {
     const lOutStream = new WritableTestStream(/^\[\]/);
     const lErrorStream = new WritableTestStream();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -81,6 +81,12 @@ function getArguments(pArguments: string[]): IArguments {
         type: "boolean",
         default: false,
       },
+      extensions: {
+        type: "string",
+        short: "x",
+        default:
+          "cjs,cjsx,coffee,csx,cts,js,json,jsx,litcoffee,ls,mjs,mts,svelte,ts,tsx,vue,vuex",
+      },
       help: { type: "boolean", short: "h", default: false },
       version: { type: "boolean", short: "V", default: false },
     },

--- a/src/format/format.spec.ts
+++ b/src/format/format.spec.ts
@@ -8,9 +8,9 @@ describe("format", () => {
     throws(() => format([], "this format is not known"));
   });
   it("returns a regex when passed regex as a format", () => {
-    deepEqual(format([], "regex"), "^()$");
+    deepEqual(format([], "regex", ""), "^()$");
   });
   it("returns json when passed json as a format", () => {
-    deepEqual(format([], "json"), "[]");
+    deepEqual(format([], "json", ""), "[]");
   });
 });

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -4,7 +4,7 @@ import formatAsJSON from "./json.js";
 
 const OUTPUT_TYPE_TO_FUNCTION: Map<
   outputTypeType,
-  (pChanges: IChange[]) => string
+  (pChanges: IChange[], pExtensions: Set<string>) => string
 > = new Map([
   ["regex", formatAsRegex],
   ["json", formatAsJSON],
@@ -13,9 +13,16 @@ const OUTPUT_TYPE_TO_FUNCTION: Map<
 export function format(
   pChanges: IChange[],
   pOutputType: outputTypeType,
+  pExtensions: string,
 ): string {
+  const lExtensions: Set<string> = new Set(
+    pExtensions
+      .split(",")
+      .map((pExtension) => pExtension.trim())
+      .map((pExtension) => `.${pExtension}`),
+  );
   // @ts-expect-error ts(2722) - Object is possibly 'undefined' - that's not
   // possible // because the OUTPUT_TYPE_TO_FUNCTION map contains all possible
   // output types
-  return OUTPUT_TYPE_TO_FUNCTION.get(pOutputType)(pChanges);
+  return OUTPUT_TYPE_TO_FUNCTION.get(pOutputType)(pChanges, lExtensions);
 }

--- a/src/format/regex.spec.ts
+++ b/src/format/regex.spec.ts
@@ -3,6 +3,8 @@ import { describe, it } from "node:test";
 import type { IChange } from "../../types/watskeburt.js";
 import format from "./regex.js";
 
+const EXTENSION_SET = new Set([".mjs"]);
+
 describe("regex formatter", () => {
   const lChangesOfEachType: IChange[] = [
     { type: "added", name: "added.mjs" },
@@ -26,31 +28,34 @@ describe("regex formatter", () => {
 
   it("one file in diff yields regex with that thing", () => {
     deepEqual(
-      format([{ type: "added", name: "added.mjs" }]),
+      format([{ type: "added", name: "added.mjs" }], EXTENSION_SET),
       "^(added[.]mjs)$",
     );
   });
 
   it("one file in diff with a backslash in its name (wut) yields regex with that thing", () => {
     deepEqual(
-      format([{ type: "added", name: "ad\\ded.mjs" }]),
+      format([{ type: "added", name: "ad\\ded.mjs" }], EXTENSION_SET),
       "^(ad\\\\ded[.]mjs)$",
     );
   });
 
   it(">1 file in diff yields regex with these things thing", () => {
     deepEqual(
-      format([
-        { type: "added", name: "added.mjs" },
-        { type: "modified", name: "changed.mjs" },
-      ]),
+      format(
+        [
+          { type: "added", name: "added.mjs" },
+          { type: "modified", name: "changed.mjs" },
+        ],
+        EXTENSION_SET,
+      ),
       "^(added[.]mjs|changed[.]mjs)$",
     );
   });
 
   it("by default only takes changes into account that changed the contents + untracked files", () => {
     deepEqual(
-      format(lChangesOfEachType),
+      format(lChangesOfEachType, EXTENSION_SET),
       "^(added[.]mjs|copied[.]mjs|modified[.]mjs|renamed[.]mjs|untracked[.]mjs)$",
     );
   });

--- a/src/format/regex.ts
+++ b/src/format/regex.ts
@@ -1,8 +1,6 @@
 import { extname } from "node:path";
 import type { IChange, changeType } from "../../types/watskeburt.js";
 
-const DEFAULT_EXTENSIONS = new Set([]);
-
 const DEFAULT_CHANGE_TYPES: Set<changeType> = new Set([
   "modified",
   "added",
@@ -13,7 +11,7 @@ const DEFAULT_CHANGE_TYPES: Set<changeType> = new Set([
 
 export default function formatAsRegex(
   pChanges: IChange[],
-  pExtensions: Set<string> = DEFAULT_EXTENSIONS,
+  pExtensions: Set<string>,
   pChangeTypes: Set<changeType> = DEFAULT_CHANGE_TYPES,
 ): string {
   const lChanges = pChanges

--- a/src/format/regex.ts
+++ b/src/format/regex.ts
@@ -1,25 +1,7 @@
 import { extname } from "node:path";
 import type { IChange, changeType } from "../../types/watskeburt.js";
 
-const DEFAULT_EXTENSIONS = new Set([
-  ".cjs",
-  ".cjsx",
-  ".coffee",
-  ".csx",
-  ".cts",
-  ".js",
-  ".json",
-  ".jsx",
-  ".litcoffee",
-  ".ls",
-  ".mjs",
-  ".mts",
-  ".svelte",
-  ".ts",
-  ".tsx",
-  ".vue",
-  ".vuex",
-]);
+const DEFAULT_EXTENSIONS = new Set([]);
 
 const DEFAULT_CHANGE_TYPES: Set<changeType> = new Set([
   "modified",

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ export async function list(pOptions?: IOptions): Promise<IChange[] | string> {
     return lChanges;
   }
   const { format } = await import("./format/format.js");
-  return format(lChanges, lOptions.outputType);
+  return format(lChanges, lOptions.outputType, lOptions.extensions);
 }
 
 // Although it looks like getSHA could be re-exported e.g.

--- a/src/map-change-type.ts
+++ b/src/map-change-type.ts
@@ -1,6 +1,6 @@
 import type { changeType } from "../types/watskeburt.js";
 
-const CHANGE_CHAR_2_CHANGE_TYPE: Map<string, changeType> = new Map([
+const CHANGE_TYPE_MAP: Map<string, changeType> = new Map([
   ["A", "added"],
   ["C", "copied"],
   ["D", "deleted"],
@@ -14,6 +14,6 @@ const CHANGE_CHAR_2_CHANGE_TYPE: Map<string, changeType> = new Map([
   ["!", "ignored"],
   // ["X", "unknown"]
 ]);
-export function changeChar2ChangeType(pChar: string): changeType {
-  return CHANGE_CHAR_2_CHANGE_TYPE.get(pChar) ?? "unknown";
+export function mapChangeType(pChar: string): changeType {
+  return CHANGE_TYPE_MAP.get(pChar) ?? "unknown";
 }

--- a/src/parse-diff-lines.ts
+++ b/src/parse-diff-lines.ts
@@ -4,7 +4,7 @@
 /* eslint-disable security/detect-unsafe-regex */
 import { EOL } from "node:os";
 import type { IChange } from "../types/watskeburt.js";
-import { changeChar2ChangeType } from "./map-change-type.js";
+import { mapChangeType } from "./map-change-type.js";
 
 const DIFF_NAME_STATUS_LINE_PATTERN =
   /^(?<type>[ACDMRTUXB])(?<similarity>[0-9]{3})?[ \t]+(?<name>[^ \t]+)[ \t]*(?<newName>[^ \t]+)?$/;
@@ -22,7 +22,7 @@ export function parseDiffLine(pString: string): Partial<IChange> {
   const lReturnValue: Partial<IChange> = {};
 
   if (lMatchResult?.groups) {
-    lReturnValue.type = changeChar2ChangeType(lMatchResult.groups.type);
+    lReturnValue.type = mapChangeType(lMatchResult.groups.type);
     if (lMatchResult.groups.newName) {
       lReturnValue.name = lMatchResult.groups.newName;
       lReturnValue.oldName = lMatchResult.groups.name;

--- a/src/parse-status-lines.ts
+++ b/src/parse-status-lines.ts
@@ -4,7 +4,7 @@
 /* eslint-disable security/detect-unsafe-regex */
 import { EOL } from "node:os";
 import type { IChange } from "../types/watskeburt.js";
-import { changeChar2ChangeType } from "./map-change-type.js";
+import { mapChangeType } from "./map-change-type.js";
 
 const DIFF_SHORT_STATUS_LINE_PATTERN =
   /^(?<stagedType>[ ACDMRTUXB?!])(?<unStagedType>[ ACDMRTUXB?!])[ \t]+(?<name>[^ \t]+)(( -> )(?<newName>[^ \t]+))?$/;
@@ -22,10 +22,8 @@ export function parseStatusLine(pString: string): Partial<IChange> {
   const lReturnValue: Partial<IChange> = {};
 
   if (lMatchResult?.groups) {
-    const lStagedType = changeChar2ChangeType(lMatchResult.groups.stagedType);
-    const lUnStagedType = changeChar2ChangeType(
-      lMatchResult.groups.unStagedType,
-    );
+    const lStagedType = mapChangeType(lMatchResult.groups.stagedType);
+    const lUnStagedType = mapChangeType(lMatchResult.groups.unStagedType);
 
     lReturnValue.type =
       lStagedType === "unmodified" ? lUnStagedType : lStagedType;

--- a/types/watskeburt.d.ts
+++ b/types/watskeburt.d.ts
@@ -52,6 +52,11 @@ export interface IFormatOptions extends IBaseOptions {
    * The type of output to deliver.
    */
   outputType: "regex" | "json";
+
+  /**
+   * A comma-separated list of file extensions to include in the output
+   */
+  extensions: string;
 }
 
 export interface IInternalOptions extends IBaseOptions {


### PR DESCRIPTION
## Description

- enables passing extensions to the (regex) reporter(s) to the cli

## Motivation and Context

Adds a bit of flexibility.

## How Has This Been Tested?

- [x] green ci
- [x] additional & adapted unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/main/.github/CONTRIBUTING.md).
