### PR TITLE
feat(cli): adds 'all extensions' option to --extensions, makes the short version -e in stead of -x

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -62,7 +62,7 @@ function getArguments(pArguments) {
 			},
 			extensions: {
 				type: "string",
-				short: "x",
+				short: "e",
 				default:
 					"cjs,cjsx,coffee,csx,cts,js,json,jsx,litcoffee,ls,mjs,mts,svelte,ts,tsx,vue,vuex",
 			},

--- a/dist/format/regex.js
+++ b/dist/format/regex.js
@@ -15,7 +15,7 @@ export default function formatAsRegex(
 		.filter(
 			(pChange) =>
 				pChangeTypes.has(pChange.type) &&
-				pExtensions.has(extname(pChange.name)),
+				(pExtensions.has(".*") || pExtensions.has(extname(pChange.name))),
 		)
 		.map(({ name }) => name.replace(/\\/g, "\\\\").replace(/\./g, "[.]"))
 		.join("|");

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -68,9 +68,9 @@ describe("cli", () => {
   it("shows an error when --extensions didn't get a string passed", async () => {
     const lOutStream = new WritableTestStream();
     const lErrorStream = new WritableTestStream(
-      /ERROR: Option '-x, --extensions <value>' argument missing.*/,
+      /ERROR: Option '-e, --extensions <value>' argument missing.*/,
     );
-    await cli(["-x"], lOutStream, lErrorStream, 0);
+    await cli(["-e"], lOutStream, lErrorStream, 0);
   });
 
   it("emits ", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,7 +84,7 @@ function getArguments(pArguments: string[]): IArguments {
       },
       extensions: {
         type: "string",
-        short: "x",
+        short: "e",
         default:
           "cjs,cjsx,coffee,csx,cts,js,json,jsx,litcoffee,ls,mjs,mts,svelte,ts,tsx,vue,vuex",
       },

--- a/src/format/regex.spec.ts
+++ b/src/format/regex.spec.ts
@@ -105,4 +105,38 @@ describe("regex formatter", () => {
       "^(added[.]aap|modified[.]aap|added[.]noot|added[.]mies)$",
     );
   });
+  it("when list of extensions contains '.*', returns all the things", () => {
+    deepEqual(
+      format(
+        [
+          {
+            type: "added",
+            name: "added.aap",
+          },
+          {
+            type: "modified",
+            name: "modified.aap",
+          },
+          {
+            type: "added",
+            name: "added.noot",
+          },
+          {
+            type: "added",
+            name: "added.mies",
+          },
+          {
+            type: "added",
+            name: "added.wim",
+          },
+          {
+            type: "added",
+            name: "added.zus",
+          },
+        ],
+        new Set([".*"]),
+      ),
+      "^(added[.]aap|modified[.]aap|added[.]noot|added[.]mies|added[.]wim|added[.]zus)$",
+    );
+  });
 });

--- a/src/format/regex.ts
+++ b/src/format/regex.ts
@@ -18,7 +18,7 @@ export default function formatAsRegex(
     .filter(
       (pChange) =>
         pChangeTypes.has(pChange.type) &&
-        pExtensions.has(extname(pChange.name)),
+        (pExtensions.has(".*") || pExtensions.has(extname(pChange.name))),
     )
     .map(({ name }) => name.replace(/\\/g, "\\\\").replace(/\./g, "[.]"))
     .join("|");

--- a/types/watskeburt.d.ts
+++ b/types/watskeburt.d.ts
@@ -55,7 +55,7 @@ export interface IFormatOptions extends IBaseOptions {
 
   /**
    * A comma-separated list of file extensions to include in the output.
-   * When list includes "*" all files are included. Currently applicable
+   * When the list includes "*" all files are included. Currently applicable
    * to the "regex" outputType only.
    */
   extensions: string;

--- a/types/watskeburt.d.ts
+++ b/types/watskeburt.d.ts
@@ -54,7 +54,9 @@ export interface IFormatOptions extends IBaseOptions {
   outputType: "regex" | "json";
 
   /**
-   * A comma-separated list of file extensions to include in the output
+   * A comma-separated list of file extensions to include in the output.
+   * When list includes "*" all files are included. Currently applicable
+   * to the "regex" outputType only.
    */
   extensions: string;
 }


### PR DESCRIPTION
## Description

- adds 'all extensions' option to `--extensions`; pass `"*"` to make the regex reporter skip the filtering on extensions. The `*` does need to be wrapped in quotes to prevent the shell from glob-expanding it.
- makes the short version of `--extensions` `-e` in stead of `-x`

## Motivation and Context

Sometimes, even the regex formatter needs to be reporting all the the things. Also see #49.

## How Has This Been Tested?

- [x] green ci
- [x] additional unit test

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/main/.github/CONTRIBUTING.md).
