### PR TITLE
fix(parse): replaces os.EOL with a platform-independent regex so there's less issues on windows

### DIFF
--- a/dist/parse-diff-lines.js
+++ b/dist/parse-diff-lines.js
@@ -1,10 +1,9 @@
-import { EOL } from "node:os";
 import { mapChangeType } from "./map-change-type.js";
 const DIFF_NAME_STATUS_LINE_PATTERN =
 	/^(?<type>[ACDMRTUXB])(?<similarity>\d{3})?[ \t]+(?<name>[^ \t]+)[ \t]*(?<newName>[^ \t]+)?$/;
 export function parseDiffLines(pString) {
 	return pString
-		.split(EOL)
+		.split(/\r?\n/)
 		.filter(Boolean)
 		.map(parseDiffLine)
 		.filter(({ name, type }) => Boolean(name) && Boolean(type));

--- a/dist/parse-status-lines.js
+++ b/dist/parse-status-lines.js
@@ -1,10 +1,9 @@
-import { EOL } from "node:os";
 import { mapChangeType } from "./map-change-type.js";
 const DIFF_SHORT_STATUS_LINE_PATTERN =
 	/^(?<stagedType>[ ACDMRTUXB?!])(?<unStagedType>[ ACDMRTUXB?!])[ \t]+(?<name>[^ \t]+)(( -> )(?<newName>[^ \t]+))?$/;
 export function parseStatusLines(pString) {
 	return pString
-		.split(EOL)
+		.split(/\r?\n/)
 		.filter(Boolean)
 		.map(parseStatusLine)
 		.filter(({ name, type }) => Boolean(name) && Boolean(type));

--- a/src/parse-diff-lines.spec.ts
+++ b/src/parse-diff-lines.spec.ts
@@ -78,4 +78,21 @@ describe("convert a bunch of diff lines to an array of change objects", () => {
       ],
     );
   });
+
+  it("bunch of valid lines deliver array of change records - even with windows style EOL", () => {
+    deepEqual(
+      parseDiffLines(["A\tthisjusadded", "R100\tfrom\tto"].join("\r\n")),
+      [
+        {
+          type: "added",
+          name: "thisjusadded",
+        },
+        {
+          type: "renamed",
+          name: "to",
+          oldName: "from",
+        },
+      ],
+    );
+  });
 });

--- a/src/parse-diff-lines.ts
+++ b/src/parse-diff-lines.ts
@@ -9,11 +9,17 @@ const DIFF_NAME_STATUS_LINE_PATTERN =
   /^(?<type>[ACDMRTUXB])(?<similarity>\d{3})?[ \t]+(?<name>[^ \t]+)[ \t]*(?<newName>[^ \t]+)?$/;
 
 export function parseDiffLines(pString: string): IChange[] {
-  return pString
-    .split(/\r?\n/)
-    .filter(Boolean)
-    .map(parseDiffLine)
-    .filter(({ name, type }) => Boolean(name) && Boolean(type)) as IChange[];
+  return (
+    pString
+      // os.EOL looks like the better choice here, however, even though os.EOL
+      // might report `\n` as a line ending, the output of the git command
+      // might still use `\r\n` as a line ending - or the other way around.
+      // Hence, for parsing, we use this platform independent regex.
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map(parseDiffLine)
+      .filter(({ name, type }) => Boolean(name) && Boolean(type)) as IChange[]
+  );
 }
 
 export function parseDiffLine(pString: string): Partial<IChange> {

--- a/src/parse-diff-lines.ts
+++ b/src/parse-diff-lines.ts
@@ -2,7 +2,6 @@
 // groups very well - false-flagging below regular expressions to be susceptible
 // to redos  attacks.
 /* eslint-disable security/detect-unsafe-regex */
-import { EOL } from "node:os";
 import type { IChange } from "../types/watskeburt.js";
 import { mapChangeType } from "./map-change-type.js";
 
@@ -11,7 +10,7 @@ const DIFF_NAME_STATUS_LINE_PATTERN =
 
 export function parseDiffLines(pString: string): IChange[] {
   return pString
-    .split(EOL)
+    .split(/\r?\n/)
     .filter(Boolean)
     .map(parseDiffLine)
     .filter(({ name, type }) => Boolean(name) && Boolean(type)) as IChange[];

--- a/src/parse-status-lines.spec.ts
+++ b/src/parse-status-lines.spec.ts
@@ -80,4 +80,45 @@ describe("convert status lines to change objects", () => {
       ],
     );
   });
+  it("bunch of valid lines deliver array of change records - even with windows style EOL", () => {
+    deepEqual(
+      parseStatusLines(
+        [
+          "R  old -> new",
+          "M  modstaged",
+          "MM modboth",
+          "?? nottracked",
+          "!! ignore",
+          "D  deleted",
+        ].join("\r\n"),
+      ),
+      [
+        {
+          type: "renamed",
+          name: "new",
+          oldName: "old",
+        },
+        {
+          type: "modified",
+          name: "modstaged",
+        },
+        {
+          type: "modified",
+          name: "modboth",
+        },
+        {
+          type: "untracked",
+          name: "nottracked",
+        },
+        {
+          type: "ignored",
+          name: "ignore",
+        },
+        {
+          type: "deleted",
+          name: "deleted",
+        },
+      ],
+    );
+  });
 });

--- a/src/parse-status-lines.ts
+++ b/src/parse-status-lines.ts
@@ -9,11 +9,17 @@ const DIFF_SHORT_STATUS_LINE_PATTERN =
   /^(?<stagedType>[ ACDMRTUXB?!])(?<unStagedType>[ ACDMRTUXB?!])[ \t]+(?<name>[^ \t]+)(( -> )(?<newName>[^ \t]+))?$/;
 
 export function parseStatusLines(pString: string): IChange[] {
-  return pString
-    .split(/\r?\n/)
-    .filter(Boolean)
-    .map(parseStatusLine)
-    .filter(({ name, type }) => Boolean(name) && Boolean(type)) as IChange[];
+  return (
+    pString
+      // os.EOL looks like the better choice here, however, even though os.EOL
+      // might report `\n` as a line ending, the output of the git command
+      // might still use `\r\n` as a line ending - or the other way around.
+      // Hence, for parsing, we use this platform independent regex.
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map(parseStatusLine)
+      .filter(({ name, type }) => Boolean(name) && Boolean(type)) as IChange[]
+  );
 }
 
 export function parseStatusLine(pString: string): Partial<IChange> {

--- a/src/parse-status-lines.ts
+++ b/src/parse-status-lines.ts
@@ -2,7 +2,6 @@
 // groups very well - false-flagging below regular expressions to be susceptible
 // to redos  attacks.
 /* eslint-disable security/detect-unsafe-regex */
-import { EOL } from "node:os";
 import type { IChange } from "../types/watskeburt.js";
 import { mapChangeType } from "./map-change-type.js";
 
@@ -11,7 +10,7 @@ const DIFF_SHORT_STATUS_LINE_PATTERN =
 
 export function parseStatusLines(pString: string): IChange[] {
   return pString
-    .split(EOL)
+    .split(/\r?\n/)
     .filter(Boolean)
     .map(parseStatusLine)
     .filter(({ name, type }) => Boolean(name) && Boolean(type)) as IChange[];


### PR DESCRIPTION
## Description

replaces os.EOL with a platform-independent regex

## Motivation and Context

See #49 

## How Has This Been Tested?

- [x] green ci
- [ ] additional unit tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/main/.github/CONTRIBUTING.md).
