### PR TITLE
fix(format): defaults 'extensions' to '*'

### DIFF
--- a/dist/format/format.js
+++ b/dist/format/format.js
@@ -6,7 +6,9 @@ const OUTPUT_TYPE_TO_FUNCTION = new Map([
 ]);
 export function format(pChanges, pOutputType, pExtensions) {
 	const lExtensions = new Set(
-		pExtensions.split(",").map((pExtension) => `.${pExtension.trim()}`),
+		(pExtensions ?? "*")
+			.split(",")
+			.map((pExtension) => `.${pExtension.trim()}`),
 	);
 	return OUTPUT_TYPE_TO_FUNCTION.get(pOutputType)(pChanges, lExtensions);
 }

--- a/src/format/format.spec.ts
+++ b/src/format/format.spec.ts
@@ -13,4 +13,57 @@ describe("format", () => {
   it("returns json when passed json as a format", () => {
     deepEqual(format([], "json", ""), "[]");
   });
+  it("doesn't throw a TypeError when 'extensions' aren't provided", () => {
+    // @ts-expect-error 2554 - Expected 3 arguments, but got 2 is a correct
+    // error, but we want to test the behavior of the function
+    // when it's not passed at all, which is very possible in javascript
+    // and (with a ts-expect-error comment) in typescript as well.
+    deepEqual(format([], "regex"), "^()$");
+  });
+  it("ensures regexp doesn't filter if no extensions are provided", () => {
+    deepEqual(
+      // @ts-expect-error 2554 - see above
+      format(
+        [
+          {
+            type: "modified",
+            name: "dist/format/format.js",
+          },
+          {
+            type: "modified",
+            name: "src/format/format.spec.ts",
+          },
+          {
+            type: "modified",
+            name: "src/format/format.ts",
+          },
+        ],
+        "regex",
+      ),
+      "^(dist/format/format[.]js|src/format/format[.]spec[.]ts|src/format/format[.]ts)$",
+    );
+  });
+  it("ensures regexp _does_ filter when provided with the empty string as list of extensions)", () => {
+    deepEqual(
+      format(
+        [
+          {
+            type: "modified",
+            name: "dist/format/format.js",
+          },
+          {
+            type: "modified",
+            name: "src/format/format.spec.ts",
+          },
+          {
+            type: "modified",
+            name: "src/format/format.ts",
+          },
+        ],
+        "regex",
+        "",
+      ),
+      "^()$",
+    );
+  });
 });

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -16,7 +16,9 @@ export function format(
   pExtensions: string,
 ): string {
   const lExtensions: Set<string> = new Set(
-    pExtensions.split(",").map((pExtension) => `.${pExtension.trim()}`),
+    (pExtensions ?? "*")
+      .split(",")
+      .map((pExtension) => `.${pExtension.trim()}`),
   );
   // @ts-expect-error ts(2722) - Object is possibly 'undefined' - that's not
   // possible // because the OUTPUT_TYPE_TO_FUNCTION map contains all possible


### PR DESCRIPTION
## Description

- when in 'format' _extensions_ aren't passed, instead of throwing a TypeError, default to _all extensions_

## Motivation and Context

Addresses an issue raised in #49 

## How Has This Been Tested?

- [x] green ci
- [x] additional automated non-regression tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/main/.github/CONTRIBUTING.md).
