### PR TITLE
doc(cli): unhides the --extension cli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,16 @@ Options:
   -T, --outputType <type>  what format to emit (choices: "json", "regex", default: "regex")
   --trackedOnly            only take tracked files into account (default: false)
   -V, --version            output the version number
+  -e, --extensions <list>  comma separated list of file extensions to consider
+                           - pass "*" to consider all extensions
+                           - currently applicable only to the "regex" reporter
+                           - defaults to to most popular extensions in the
+                             JavaScript/ TypeScript ecosystem
   -h, --help               display help for command
 ```
+
+Default list of extensions (cli, regex reporter only):
+`"cjs, cjsx, coffee, csx, cts, js, json, jsx, litcoffee, ls, mjs, mts, svelte, ts, tsx, vue, vuex"`.
 
 ## why?
 

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -11,6 +11,11 @@ lists files & their statuses since [old-revision] or between [old-revision] and 
 Options:
   -T, --outputType <type>  what format to emit (choices: "json", "regex", default: "regex")
   --trackedOnly            only take tracked files into account (default: false)
+  -e, --extensions <list>  comma separated list of file extensions to consider 
+                           - pass "*" to consider all extensions
+                           - currently applicable only to the "regex" reporter
+                           - defaults to to most popular extensions in the 
+                             JavaScript/ TypeScript ecosystem
   -V, --version            output the version number
   -h, --help               display help for command${EOL}`;
 export async function cli(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,11 @@ lists files & their statuses since [old-revision] or between [old-revision] and 
 Options:
   -T, --outputType <type>  what format to emit (choices: "json", "regex", default: "regex")
   --trackedOnly            only take tracked files into account (default: false)
+  -e, --extensions <list>  comma separated list of file extensions to consider 
+                           - pass "*" to consider all extensions
+                           - currently applicable only to the "regex" reporter
+                           - defaults to to most popular extensions in the 
+                             JavaScript/ TypeScript ecosystem
   -V, --version            output the version number
   -h, --help               display help for command${EOL}`;
 


### PR DESCRIPTION
## Description

- un-hides the (already existing for a few versions) --extension cli option

## Motivation and Context

pProbably ok now that we have had it in silently for a few months. Also got a use in case you'd want to get a regex that is not limited to JavaScript ecosystem stuffs.

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/watskeburt/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/watskeburt/blob/main/.github/CONTRIBUTING.md).
